### PR TITLE
[Feat] 레이아웃에서 스코어 모달 연결 및 메뉴바 내정보 페이지 연결 #1

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,9 +1,10 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { userState, liveState } from '../../utils/recoil/main';
 import { UserData, LiveData } from '../../types/mainType';
+import InputScoreModal from '../score/InputScoreModal';
 import Header from './Header';
 import Footer from './Footer';
 import { getData } from '../../utils/axios';
@@ -15,7 +16,7 @@ type AppLayoutProps = {
 
 export default function AppLayout({ children }: AppLayoutProps) {
   const [userData, setUserData] = useRecoilState<UserData>(userState);
-  const setLiveData = useSetRecoilState<LiveData>(liveState);
+  const [liveData, setLiveData] = useRecoilState<LiveData>(liveState);
   const userId = userData.userId;
   const presentPath = useRouter().asPath;
 
@@ -44,6 +45,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
 
   return (
     <>
+      {/* {liveData.gameId && <InputScoreModal gameId={liveData.gameId} />} */}
       <Header />
       {presentPath !== '/match' && (
         <Link href='/match'>

--- a/components/Layout/MenuBar.tsx
+++ b/components/Layout/MenuBar.tsx
@@ -1,4 +1,7 @@
 import { useRouter } from 'next/router';
+import { useRecoilValue } from 'recoil';
+import { userState } from '../../utils/recoil/main';
+import { UserData } from '../../types/mainType';
 import styles from '../../styles/MenuBar.module.scss';
 
 type MenuBarProps = {
@@ -6,6 +9,7 @@ type MenuBarProps = {
 };
 
 export default function MenuBar({ showMenuBarHandler }: MenuBarProps) {
+  const userData = useRecoilValue<UserData>(userState);
   const router = useRouter();
 
   const MenuPathHandler = (path: string) => {
@@ -20,7 +24,9 @@ export default function MenuBar({ showMenuBarHandler }: MenuBarProps) {
           <ul>
             <li onClick={() => MenuPathHandler('rank')}>랭킹</li>
             <li onClick={() => MenuPathHandler('game')}>최근 경기</li>
-            <li onClick={() => MenuPathHandler('')}>내 정보</li>
+            <li onClick={() => MenuPathHandler(`users/${userData.userId}`)}>
+              내 정보
+            </li>
           </ul>
         </nav>
         <nav>

--- a/components/score/InputScoreModal.tsx
+++ b/components/score/InputScoreModal.tsx
@@ -4,7 +4,7 @@ import { PlayerInfo, GameResult } from '../../types/scoreTypes';
 import styles from '../../styles/InputScoreModal.module.scss';
 
 type GameProps = {
-  gameId: string;
+  gameId: number;
 };
 
 export default function InputScoreModal({ gameId }: GameProps) {

--- a/pages/score.tsx
+++ b/pages/score.tsx
@@ -1,9 +1,0 @@
-import InputScoreModal from '../components/score/InputScoreModal';
-
-export default function Score() {
-  return (
-    <div>
-      <InputScoreModal gameId='1' />
-    </div>
-  );
-}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 레이아웃과 스코어 입력 모달창 연결(레이아웃에서 보여줘 모든 페이지에서 입력창을 띄웁니다.)
  - 메뉴바 내정보 페이지 연결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 레이아웃의 liveData에서 gameId가 있을 때 스코어 입력 모달창 보여주기
      - 모든 창에서 보여주어 일단 주석처리해놨습니다 
  - 메뉴바의 내정보 클릭시 내정보 페이지 연결

