### PR TITLE
[Faet] 레이아웃에서 현재매치정보 컴포넌트 연결

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { userState, liveState } from '../../utils/recoil/main';
 import { UserData, LiveData } from '../../types/mainType';
+import InputScoreModal from '../score/InputScoreModal';
+import CurrentMatchInfo from '../match/CurrentMatchInfo';
 import Header from './Header';
 import Footer from './Footer';
 import { getData } from '../../utils/axios';
@@ -15,8 +17,7 @@ type AppLayoutProps = {
 
 export default function AppLayout({ children }: AppLayoutProps) {
   const [userData, setUserData] = useRecoilState<UserData>(userState);
-  const setLiveData = useSetRecoilState<LiveData>(liveState);
-  const userId = userData.userId;
+  const [liveData, setLiveData] = useRecoilState<LiveData>(liveState);
   const presentPath = useRouter().asPath;
 
   useEffect(() => {
@@ -30,7 +31,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
   }, []);
 
   useEffect(() => {
-    getLiveDataHandler(userId);
+    getLiveDataHandler(userData.userId);
   }, [presentPath]);
 
   const getLiveDataHandler = async (userId: string) => {
@@ -45,6 +46,9 @@ export default function AppLayout({ children }: AppLayoutProps) {
   return (
     <>
       <Header />
+      {/* 목업 서버에 항상 gameId를 갖고 있어 서버 연결 후 주석 해제 예정 */}
+      {/* {liveData.gameId && <InputScoreModal gameId={liveData.gameId} />} */}
+      {liveData.event === 'match' && <CurrentMatchInfo />}
       {presentPath !== '/match' && (
         <Link href='/match'>
           <a className='matchingButton'>

--- a/components/Layout/MenuBar.tsx
+++ b/components/Layout/MenuBar.tsx
@@ -1,4 +1,7 @@
 import { useRouter } from 'next/router';
+import { useRecoilValue } from 'recoil';
+import { userState } from '../../utils/recoil/main';
+import { UserData } from '../../types/mainType';
 import styles from '../../styles/MenuBar.module.scss';
 
 type MenuBarProps = {
@@ -6,6 +9,7 @@ type MenuBarProps = {
 };
 
 export default function MenuBar({ showMenuBarHandler }: MenuBarProps) {
+  const userData = useRecoilValue<UserData>(userState);
   const router = useRouter();
 
   const MenuPathHandler = (path: string) => {
@@ -20,7 +24,9 @@ export default function MenuBar({ showMenuBarHandler }: MenuBarProps) {
           <ul>
             <li onClick={() => MenuPathHandler('rank')}>랭킹</li>
             <li onClick={() => MenuPathHandler('game')}>최근 경기</li>
-            <li onClick={() => MenuPathHandler('')}>내 정보</li>
+            <li onClick={() => MenuPathHandler(`users/${userData.userId}`)}>
+              내 정보
+            </li>
           </ul>
         </nav>
         <nav>

--- a/pages/api/pingpong/users/[userId]/live.ts
+++ b/pages/api/pingpong/users/[userId]/live.ts
@@ -8,6 +8,7 @@ export default function handler(
   const obj = {
     notiCount: 9,
     gameId: 12,
+    event: 'match',
   };
   res.status(200).json(obj);
 }

--- a/types/mainType.ts
+++ b/types/mainType.ts
@@ -6,6 +6,7 @@ export interface UserData {
 export interface LiveData {
   notiCount: number;
   gameId: number | null;
+  event: string | null;
 }
 
 export interface SearchData {

--- a/utils/recoil/main.ts
+++ b/utils/recoil/main.ts
@@ -9,5 +9,5 @@ export const userState = atom<UserData>({
 
 export const liveState = atom<LiveData>({
   key: `liveState/${v1()}`,
-  default: { notiCount: 0, gameId: null },
+  default: { notiCount: 0, gameId: null, event: null },
 });


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 레이아웃에서 현재매치정보 컴포넌트 연결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - liveData에 event 데이터 추가: match 이벤트 발생시 'match' 받아옴
    - recoil, api, type 수정
  - event: 'match'일 때 CurrentMatchInfo컴포넌트를 보여줌
