### PR TITLE
[Feat] 서버데이터 연동 및 리스트 페이지 분기처리

### DIFF
--- a/components/game/GameResultList.tsx
+++ b/components/game/GameResultList.tsx
@@ -1,23 +1,30 @@
 import { useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { Game } from '../../types/gameTypes';
 import infScroll from '../../utils/infinityScroll';
 import { clickedGameItem } from '../../utils/recoil/game';
 import GameResultItem from './GameResultItem';
 
 type gameResultTypes = {
-  user: string;
+  path: string;
+  isMain: boolean;
 };
 
-export default function GameResultList(user: gameResultTypes) {
+export default function GameResultList({ path, isMain }: gameResultTypes) {
   const [clickedItemId, setClickedItemId] =
     useRecoilState<number>(clickedGameItem);
-  const result = infScroll(`/pingpong/games?page=`);
-  const { data, fetchNextPage, status } = result;
+  const [lastGameId, setLastGameId] = useState<number>();
+  const infResult = infScroll(path, true);
+  const { data, fetchNextPage, status } = infResult;
+
+  const getLastGameId = (data: any) => {
+    return data?.pages[data.pages.length - 1].lastGameId;
+  };
 
   useEffect(() => {
-    if (data?.pages.length === 1)
+    if (data?.pages.length === 1 && getLastGameId(data) !== 0)
       setClickedItemId(data?.pages[0].games[0].gameId);
+    setLastGameId(getLastGameId(data));
   }, [data]);
 
   return (
@@ -26,7 +33,7 @@ export default function GameResultList(user: gameResultTypes) {
         <>
           {data?.pages.map((page, index) => (
             <div key={index}>
-              {page.games.map((game: Game, index: number) => (
+              {page.games.map((game: Game) => (
                 <GameResultItem
                   key={game.gameId}
                   game={game}
@@ -37,7 +44,21 @@ export default function GameResultList(user: gameResultTypes) {
           ))}
         </>
       )}
-      <button onClick={() => fetchNextPage()}>전적 더보기!!</button>
+      <>
+        {!isMain ? (
+          <>
+            {lastGameId !== 0 ? (
+              <button style={{ width: '100%' }} onClick={() => fetchNextPage()}>
+                더보기
+              </button>
+            ) : (
+              '요소가 없습니다!'
+            )}
+          </>
+        ) : (
+          ''
+        )}
+      </>
     </div>
   );
 }

--- a/components/game/GameResultList.tsx
+++ b/components/game/GameResultList.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { InfiniteData } from 'react-query';
 import { useRecoilState } from 'recoil';
 import { Game } from '../../types/gameTypes';
 import infScroll from '../../utils/infinityScroll';
@@ -18,7 +19,7 @@ export default function GameResultList({ path }: gameResultTypes) {
   const { data, fetchNextPage, status } = infResult;
   const router = useRouter();
 
-  const getLastGameId = (data: any) => {
+  const getLastGameId = (data: InfiniteData<any> | undefined) => {
     return data?.pages[data.pages.length - 1].lastGameId;
   };
 

--- a/components/game/GameResultList.tsx
+++ b/components/game/GameResultList.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { Game } from '../../types/gameTypes';
@@ -7,15 +8,15 @@ import GameResultItem from './GameResultItem';
 
 type gameResultTypes = {
   path: string;
-  isMain: boolean;
 };
 
-export default function GameResultList({ path, isMain }: gameResultTypes) {
+export default function GameResultList({ path }: gameResultTypes) {
   const [clickedItemId, setClickedItemId] =
     useRecoilState<number>(clickedGameItem);
   const [lastGameId, setLastGameId] = useState<number>();
-  const infResult = infScroll(path, true);
+  const infResult = infScroll(path, false);
   const { data, fetchNextPage, status } = infResult;
+  const router = useRouter();
 
   const getLastGameId = (data: any) => {
     return data?.pages[data.pages.length - 1].lastGameId;
@@ -45,18 +46,10 @@ export default function GameResultList({ path, isMain }: gameResultTypes) {
         </>
       )}
       <>
-        {!isMain ? (
-          <>
-            {lastGameId !== 0 ? (
-              <button style={{ width: '100%' }} onClick={() => fetchNextPage()}>
-                더보기
-              </button>
-            ) : (
-              '요소가 없습니다!'
-            )}
-          </>
-        ) : (
-          ''
+        {router.asPath !== '/' && lastGameId !== 0 && (
+          <button style={{ width: '100%' }} onClick={() => fetchNextPage()}>
+            더보기
+          </button>
         )}
       </>
     </div>

--- a/components/game/GameResultPath.tsx
+++ b/components/game/GameResultPath.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import GameResultList from './GameResultList';
+
+type gameResultTypes = {
+  user?: string;
+  isMain?: boolean;
+};
+
+export default function GameResultPath({
+  user = '',
+  isMain = false,
+}: gameResultTypes) {
+  const [path, setPath] = useState<string>();
+  useEffect(() => {
+    if (isMain) {
+      setPath(`/pingpong/games?count=3&gameId=`);
+    } else if (user !== '') {
+      setPath(`/pingpong/users/${user}/games?count=4&status=end&gameId=`);
+    } else {
+      setPath(`/pingpong/games?count=4&gameId=`);
+    }
+  }, []);
+
+  const queryClient = new QueryClient();
+  return (
+    <div>
+      <QueryClientProvider client={queryClient}>
+        {!path ? '로딩중' : <GameResultList path={path} isMain={isMain} />}
+      </QueryClientProvider>
+    </div>
+  );
+}

--- a/components/game/GameResultPath.tsx
+++ b/components/game/GameResultPath.tsx
@@ -1,32 +1,27 @@
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import GameResultList from './GameResultList';
 
-type gameResultTypes = {
-  user?: string;
-  isMain?: boolean;
-};
-
-export default function GameResultPath({
-  user = '',
-  isMain = false,
-}: gameResultTypes) {
+export default function GameResultPath() {
+  const queryClient = new QueryClient();
   const [path, setPath] = useState<string>();
+  const router = useRouter();
   useEffect(() => {
-    if (isMain) {
+    console.log(router.asPath);
+    if (router.asPath === '/') {
       setPath(`/pingpong/games?count=3&gameId=`);
-    } else if (user !== '') {
-      setPath(`/pingpong/users/${user}/games?count=4&status=end&gameId=`);
+    } else if (router.asPath === '/game') {
+      setPath(`/pingpong/games?gameId=`);
     } else {
-      setPath(`/pingpong/games?count=4&gameId=`);
+      setPath(`/pingpong${router.asPath}/games?count=4&status=end&gameId=`);
     }
   }, []);
 
-  const queryClient = new QueryClient();
   return (
     <div>
       <QueryClientProvider client={queryClient}>
-        {!path ? '로딩중' : <GameResultList path={path} isMain={isMain} />}
+        {!path ? '로딩중' : <GameResultList path={path} />}
       </QueryClientProvider>
     </div>
   );

--- a/pages/api/pingpong/users/[userId]/games/1.ts
+++ b/pages/api/pingpong/users/[userId]/games/1.ts
@@ -3,12 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { Game, Team, Player } from '../../../../../../types/gameTypes';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const info = {
-    count: 16,
-    next: 'http://localhost:3000/api/pingpong/users/kipark/games/1',
-    pages: 4,
-    prev: 'null',
-  };
+  const lastGameId = 2;
   const players: Player[] = [
     {
       userId: 'kipark',
@@ -102,7 +97,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     },
   ];
   const objs = {
-    info: info,
+    lastGameId,
     games: games,
   };
   res.status(200).json(objs);

--- a/pages/api/pingpong/users/[userId]/games/2.ts
+++ b/pages/api/pingpong/users/[userId]/games/2.ts
@@ -3,12 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { Game, Team, Player } from '../../../../../../types/gameTypes';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const info = {
-    count: 16,
-    next: 'http://localhost:3000/api/pingpong/users/kipark/games/1',
-    pages: 4,
-    prev: 'http://localhost:3000/api/pingpong/users/kipark/games/3',
-  };
+  const lastGameId = 3;
   const players: Player[] = [
     {
       userId: 'kipark',
@@ -102,7 +97,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     },
   ];
   const objs = {
-    info: info,
+    lastGameId,
     games: games,
   };
   res.status(200).json(objs);

--- a/pages/api/pingpong/users/[userId]/games/3.ts
+++ b/pages/api/pingpong/users/[userId]/games/3.ts
@@ -3,12 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { Game, Team, Player } from '../../../../../../types/gameTypes';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const info = {
-    count: 16,
-    next: 'http://localhost:3000/api/pingpong/users/kipark/games/4',
-    pages: 4,
-    prev: 'http://localhost:3000/api/pingpong/users/kipark/games/2',
-  };
+  const lastGameId = 4;
   const players: Player[] = [
     {
       userId: 'kipark',
@@ -102,7 +97,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     },
   ];
   const objs = {
-    info: info,
+    lastGameId,
     games: games,
   };
   res.status(200).json(objs);

--- a/pages/api/pingpong/users/[userId]/games/4.ts
+++ b/pages/api/pingpong/users/[userId]/games/4.ts
@@ -3,12 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { Game, Team, Player } from '../../../../../../types/gameTypes';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const info = {
-    count: 16,
-    next: 'null',
-    pages: 4,
-    prev: 'http://localhost:3000/api/pingpong/users/kipark/games/3',
-  };
+  const lastGameId = 0;
   const players: Player[] = [
     {
       userId: 'kipark',
@@ -102,7 +97,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     },
   ];
   const objs = {
-    info: info,
+    lastGameId,
     games: games,
   };
   res.status(200).json(objs);

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -1,14 +1,9 @@
-import { QueryClient, QueryClientProvider } from 'react-query';
-import GameResultList from '../components/game/GameResultList';
+import GameResultPath from '../components/game/GameResultPath';
 
 export default function Game() {
-  const queryClient = new QueryClient();
-
   return (
     <div>
-      <QueryClientProvider client={queryClient}>
-        <GameResultList user='all' />
-      </QueryClientProvider>
+      <GameResultPath user='' />
     </div>
   );
 }

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -3,7 +3,7 @@ import GameResultPath from '../components/game/GameResultPath';
 export default function Game() {
   return (
     <div>
-      <GameResultPath user='' />
+      <GameResultPath />
     </div>
   );
 }

--- a/utils/infinityScroll.ts
+++ b/utils/infinityScroll.ts
@@ -5,8 +5,8 @@ const LOCAL = 'http://localhost:3000/api';
 const SERVER = 'http://211.253.28.235:9090';
 
 export default function infScroll(path: string, isServer: boolean = false) {
-  const END_POINT = isServer ? LOCAL : SERVER;
-  const getList = ({ pageParam = 1 }) =>
+  const END_POINT = isServer ? SERVER : LOCAL;
+  const getList = ({ pageParam = 210000000 }) =>
     axios
       .get(`${END_POINT}${path}${pageParam}`, {})
 
@@ -14,7 +14,7 @@ export default function infScroll(path: string, isServer: boolean = false) {
 
   const result = useInfiniteQuery('infiniteList', getList, {
     getNextPageParam: (pages) => {
-      return pages.currentPage + 1;
+      return pages.lastGameId;
     },
   });
 

--- a/utils/infinityScroll.ts
+++ b/utils/infinityScroll.ts
@@ -1,14 +1,14 @@
 import { useInfiniteQuery } from 'react-query';
 import axios from 'axios';
 
-const LOCAL = 'http://localhost:3000/api';
+const LOCAL = 'http://localhost:3000/api/pingpong/users/user/games/';
 const SERVER = 'http://211.253.28.235:9090';
 
 export default function infScroll(path: string, isServer: boolean = false) {
   const END_POINT = isServer ? SERVER : LOCAL;
-  const getList = ({ pageParam = 210000000 }) =>
+  const getList = ({ pageParam = 1 }) =>
     axios
-      .get(`${END_POINT}${path}${pageParam}`, {})
+      .get(`${LOCAL}${pageParam}`, {})
 
       .then((res) => res?.data);
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 서버데이터 연동
  - 리스트 페이지 분기처리
  - 수정사항 변경
 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 서버 api에 맞춰서 데이터 연동
  - 리스트 페이지에서 하던 분기처리를 ResultPath 컴포넌트를 만들어서 따로 처리후 list에 넘겨주기로 처리함
  -  (수정사항)
  - ResultPath에서 isMain과 user로 props를 받는게 아니라 router.asPath를 활용해서 현제 path를 받아 처리하는 방석으로 바꿈 그래서 따로 컴포넌트에 props를 넣을 필요 없이 컴포넌트만 선언하면 됨