### PR TITLE
[Fix] GameResultSmallItem key 중첩 에러 수정

### DIFF
--- a/components/game/small/GameResultSmallTeam.tsx
+++ b/components/game/small/GameResultSmallTeam.tsx
@@ -17,8 +17,8 @@ export default function GameResultSmallTeam({
         <span className={styles.userImage}></span>
         <span>
           {team.players.map((player) => (
-            <Link href={`/users/${player.userId}`}>
-              <div key={player.userId}>{player.userId}</div>
+            <Link key={player.userId} href={`/users/${player.userId}`}>
+              <div>{player.userId}</div>
             </Link>
           ))}
         </span>


### PR DESCRIPTION


<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - GameResultSmallItem 컴포넌트 key 중첩 에러 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - GameResultSmallItem intra id 에 Link를 추가 할 때 key value가 Link태그 안에 있는 div에 들어있어서 key가 중첩되는 문제가 발생함 
  - 해결하기위해 Link태그 안에 key value를 넣어줌
 
