### PR TITLE
[Fix] 현재배치정보배너 상대팀 있을 때 5분 임박시 뜨게 하기, 매치페이지 새로고침버튼과 연결 #171

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -30,8 +30,8 @@ export default function AppLayout({ children }: AppLayoutProps) {
   );
   const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
   const [errorMessage, setErrorMessage] = useRecoilState(errorState);
-  const presentPath = useRouter().asPath;
   const router = useRouter();
+  const presentPath = useRouter().asPath;
   const token = router.asPath.split('?token=')[1];
 
   useEffect(() => {

--- a/components/match/MatchBoardList.tsx
+++ b/components/match/MatchBoardList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { MatchData } from 'types/matchTypes';
+import { matchRefreshBtnState } from 'utils/recoil/match';
 import { errorState } from 'utils/recoil/error';
 import instance from 'utils/axios';
 import MatchBoard from './MatchBoard';
@@ -12,6 +13,7 @@ interface MatchBoardListProps {
 
 export default function MatchBoardList({ type }: MatchBoardListProps) {
   const [matchData, setMatchData] = useState<MatchData | null>(null);
+  const setMatchRefreshBtn = useSetRecoilState(matchRefreshBtnState);
   const setErrorMessage = useSetRecoilState(errorState);
 
   useEffect(() => {
@@ -42,8 +44,19 @@ export default function MatchBoardList({ type }: MatchBoardListProps) {
     // 매뉴얼 구현시 연결
   };
 
+  const refreshBtnHandler = () => {
+    console.log('refresh');
+    getMatchDataHandler();
+    setMatchRefreshBtn(true);
+    // setMatchRefreshBtn(false);
+  };
+
   if (filteredMatchBoards.length === 0)
-    return <div>오늘의 매치가 모두 끝났습니다!</div>;
+    return (
+      <div className={styles.matchAllClosed}>
+        오늘의 매치가 모두 끝났습니다!
+      </div>
+    );
 
   return (
     <>
@@ -51,7 +64,7 @@ export default function MatchBoardList({ type }: MatchBoardListProps) {
         <button className={styles.mamualBtn} onClick={manualPageHandler}>
           매뉴얼
         </button>
-        <button className={styles.refreshBtn} onClick={getMatchDataHandler}>
+        <button className={styles.refreshBtn} onClick={refreshBtnHandler}>
           &#8635;
         </button>
       </div>

--- a/styles/match/MatchBoardList.module.scss
+++ b/styles/match/MatchBoardList.module.scss
@@ -1,5 +1,11 @@
 @import 'styles/common.scss';
 
+.matchAllClosed {
+  margin: 3rem 0;
+  text-align: center;
+  color: #fff;
+}
+
 .matchBoardList {
   display: flex;
   flex-direction: column;

--- a/utils/axios.ts
+++ b/utils/axios.ts
@@ -11,7 +11,7 @@ instance.interceptors.request.use(
     config.headers = {
       'Content-Type': 'application/json',
       // Authorization: `Bearer ${localStorage.getItem('42gg-token')}`,
-      Authorization: `Bearer access2`, // 백에서 access1~1000까지 토큰을 임의로 바꿨습니당
+      Authorization: `Bearer access23`, // 백에서 access1~1000까지 토큰을 임의로 바꿨습니당
     };
     return config;
   },

--- a/utils/recoil/match.ts
+++ b/utils/recoil/match.ts
@@ -21,3 +21,8 @@ export const rejectModalState = atom<boolean>({
   key: `rejectModalState/${v1()}`,
   default: false,
 });
+
+export const matchRefreshBtnState = atom<boolean>({
+  key: `matchRefreshBtnState/${v1()}`,
+  default: false,
+});


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 현재배치정보배너 상대팀 있을 때 5분 임박시 뜨게 하기, 매치페이지 새로고침버튼과 연결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 현재배치정보배너 상대팀 있을 때 5분 임박시 뜨게 하기
    - useEffect 추가해 path가 바뀔때, 5분 임을 확인하고, 5분 전일 때 상대 표시하는 함수(makeEnemyTeamInfo) 실행
  - 매치페이지 새로고침버튼과 연결
    - 매치페이지, 현재 매치정보 배너에 recoil matchRefreshBtn을 추가해 매치페이지 새로고침 누를 때 true 로 상태를 바꿔 배너도 새로고침버튼에  연결
  - 매치 없을 때 안내문 스타일링
 
