### PR TITLE
[Fix] match 페이지의 모달 :  뒤로가기 시 사라지도록 수정

### DIFF
--- a/components/match/MatchBoardList.tsx
+++ b/components/match/MatchBoardList.tsx
@@ -6,7 +6,7 @@ import { errorState } from 'utils/recoil/error';
 import instance from 'utils/axios';
 import MatchBoard from './MatchBoard';
 import styles from 'styles/match/MatchBoardList.module.scss';
-import { manualModalState } from 'utils/recoil/match';
+import { matchModalState } from 'utils/recoil/match';
 
 interface MatchBoardListProps {
   type: string;
@@ -17,7 +17,7 @@ export default function MatchBoardList({ type }: MatchBoardListProps) {
   const setMatchRefreshBtn = useSetRecoilState(matchRefreshBtnState);
   const setErrorMessage = useSetRecoilState(errorState);
   const currentRef = useRef<HTMLDivElement>(null);
-  const openManualModal = useSetRecoilState(manualModalState);
+  const setMatchModal = useSetRecoilState(matchModalState);
 
   useEffect(() => {
     getMatchDataHandler();
@@ -41,7 +41,7 @@ export default function MatchBoardList({ type }: MatchBoardListProps) {
   const { matchBoards, intervalMinute } = matchData;
 
   const manualPageHandler = () => {
-    openManualModal(true);
+    setMatchModal('manual');
   };
 
   const refreshBtnHandler = () => {

--- a/components/match/MatchItem.tsx
+++ b/components/match/MatchItem.tsx
@@ -3,7 +3,7 @@ import { Slot, EnrollInfo } from 'types/matchTypes';
 import {
   cancelModalState,
   enrollInfoState,
-  rejectModalState,
+  matchModalState,
 } from 'utils/recoil/match';
 import { fillZero } from 'utils/handleTime';
 import styles from 'styles/match/MatchItem.module.scss';
@@ -21,7 +21,7 @@ export default function MatchItem({
   intervalMinute,
 }: MatchItemProps) {
   const setEnrollInfo = useSetRecoilState<EnrollInfo | null>(enrollInfoState);
-  const setOpenRejectModal = useSetRecoilState(rejectModalState);
+  const setMatchModal = useSetRecoilState(matchModalState);
   const setOpenCancelModal = useSetRecoilState<boolean>(cancelModalState);
   const liveData = useRecoilValue(liveState);
   const { headCount, slotId, status, time } = slot;
@@ -36,8 +36,9 @@ export default function MatchItem({
     if (status === 'mytable') {
       setOpenCancelModal(true);
     } else if (liveData.event === 'match') {
-      setOpenRejectModal(true);
+      setMatchModal('reject');
     } else {
+      setMatchModal('enroll');
       setEnrollInfo({
         slotId,
         type,

--- a/components/match/MatchManualModal.tsx
+++ b/components/match/MatchManualModal.tsx
@@ -1,12 +1,12 @@
 import { useSetRecoilState } from 'recoil';
 import styles from 'styles/match/MatchManual.module.scss';
-import { manualModalState } from 'utils/recoil/match';
+import { matchModalState } from 'utils/recoil/match';
 
-export default function MatchManual() {
-  const openManualModal = useSetRecoilState(manualModalState);
+export default function MatchManualModal() {
+  const setMatchModal = useSetRecoilState(matchModalState);
 
   const onReturn = () => {
-    openManualModal(false);
+    setMatchModal(null);
   };
 
   return (

--- a/components/modal/MatchEnrollModal.tsx
+++ b/components/modal/MatchEnrollModal.tsx
@@ -1,5 +1,5 @@
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { enrollInfoState } from 'utils/recoil/match';
+import { enrollInfoState, matchModalState } from 'utils/recoil/match';
 import { gameTimeToString } from 'utils/handleTime';
 import { EnrollInfo } from 'types/matchTypes';
 import { errorState } from 'utils/recoil/error';
@@ -9,6 +9,7 @@ import styles from 'styles/modal/MatchEnroll.module.scss';
 
 export default function MatchEnrollModal() {
   const setErrorMessage = useSetRecoilState(errorState);
+  const setMatchModal = useSetRecoilState(matchModalState);
   const [enrollInfo, setEnrollInfo] = useRecoilState<EnrollInfo | null>(
     enrollInfoState
   );
@@ -33,16 +34,21 @@ export default function MatchEnrollModal() {
       else if (e.response.data.code === 'SC003')
         alert('경기 취소 후 1분 동안 경기를 예약할 수 없습니다.');
       else {
+        setMatchModal(null);
         setEnrollInfo(null);
         setErrorMessage('Request Error');
         return;
       }
     }
+    setMatchModal(null);
     setEnrollInfo(null);
     window.location.reload();
   };
 
-  const onCancel = () => setEnrollInfo(null);
+  const onCancel = () => {
+    setMatchModal(null);
+    setEnrollInfo(null);
+  };
 
   return (
     <Modal>

--- a/components/modal/MatchRejectModal.tsx
+++ b/components/modal/MatchRejectModal.tsx
@@ -1,12 +1,12 @@
 import { useSetRecoilState } from 'recoil';
-import { rejectModalState } from 'utils/recoil/match';
+import { matchModalState } from 'utils/recoil/match';
 import styles from 'styles/modal/MatchRejectModal.module.scss';
 
 export default function MatchRejectModal() {
-  const setopenRejectModal = useSetRecoilState(rejectModalState);
+  const setMatchModal = useSetRecoilState(matchModalState);
 
   const onReturn = () => {
-    setopenRejectModal(false);
+    setMatchModal(null);
   };
 
   return (

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -1,32 +1,40 @@
 import MatchBoardList from 'components/match/MatchBoardList';
-import MatchManual from 'components/match/MatchManual';
+import MatchManual from 'components/match/MatchManualModal';
 import MatchEnrollModal from 'components/modal/MatchEnrollModal';
 import MatchRejectModal from 'components/modal/MatchRejectModal';
 import Modal from 'components/modal/Modal';
-import { useRecoilValue } from 'recoil';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 import styles from 'styles/match/match.module.scss';
-import { manualModalState, rejectModalState } from 'utils/recoil/match';
+import { matchModalState } from 'utils/recoil/match';
 
 export default function Match() {
-  const openRejectModal = useRecoilValue(rejectModalState);
-  const openManualModal = useRecoilValue(manualModalState);
+  const [matchModal, setMatchModal] = useRecoilState(matchModalState);
+
+  useEffect(() => {
+    return setMatchModal(null);
+  }, []);
+
+  const ModalChild = () => {
+    if (matchModal === 'enroll') return <MatchEnrollModal />;
+    else if (matchModal === 'manual') return <MatchManual />;
+    else if (matchModal === 'reject') return <MatchRejectModal />;
+    else return null;
+  };
+
+  const ModalProvider = () =>
+    matchModal ? (
+      <Modal>
+        <ModalChild />
+      </Modal>
+    ) : null;
 
   return (
     <>
-      {openManualModal && (
-        <Modal>
-          <MatchManual />
-        </Modal>
-      )}
-      {openRejectModal && (
-        <Modal>
-          <MatchRejectModal />
-        </Modal>
-      )}
       <div className={styles.container}>
         <h1 className={styles.title}>Match</h1>
         <MatchBoardList type='single' />
-        <MatchEnrollModal />
+        <ModalProvider />
       </div>
     </>
   );

--- a/pages/users/[intraId].tsx
+++ b/pages/users/[intraId].tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { isEditProfileState } from 'utils/recoil/user';
 import Chart from 'components/user/Chart';
 import Profile from 'components/user/Profile';
@@ -7,11 +7,16 @@ import EditProfileModal from 'components/modal/EditProfileModal';
 import GameResult from 'components/game/GameResult';
 import styles from 'styles/user/user.module.scss';
 import Modal from 'components/modal/Modal';
+import { useEffect } from 'react';
 
 export default function user() {
   const router = useRouter();
   const { intraId } = router.query;
-  const isEditProfile = useRecoilValue(isEditProfileState);
+  const [isEditProfile, setIsEditProfile] = useRecoilState(isEditProfileState);
+
+  useEffect(() => {
+    return setIsEditProfile(false);
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/utils/recoil/match.ts
+++ b/utils/recoil/match.ts
@@ -17,17 +17,12 @@ export const openCurrentMatchInfoState = atom<boolean>({
   default: false,
 });
 
-export const rejectModalState = atom<boolean>({
-  key: `rejectModalState/${v1()}`,
-  default: false,
-});
-
 export const matchRefreshBtnState = atom<boolean>({
   key: `matchRefreshBtnState/${v1()}`,
   default: false,
 });
 
-export const manualModalState = atom<boolean>({
-  key: `manualModalState/${v1()}`,
-  default: false,
+export const matchModalState = atom<'enroll' | 'reject' | 'manual' | null>({
+  key: `matchModalState/${v1()}`,
+  default: null,
 });


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - match 페이지의 모달 :  뒤로가기시 사라지도록 수정
  - match 취소 모달은 Layout 에 있어서 아직 작업하지 않았음
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - match 페이지에 속한 모달들 상태 하나로 묶음
    (enroll, reject, manual)
 - useEffect return 을 사용하여 언마운트시 모달 상태를 false로 만듬

 
