### PR TITLE
[Fix] 현재매치정보배너를 매치페이지 새로고침버튼, 스코어입력 모달과 연결 close #203 #207

### DIFF
--- a/components/Layout/CurrentMatchInfo.tsx
+++ b/components/Layout/CurrentMatchInfo.tsx
@@ -1,13 +1,10 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
-import {
-  useRecoilState,
-  useSetRecoilState,
-  useResetRecoilState,
-  useRecoilValue,
-} from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { CurrentMatch } from 'types/matchTypes';
+import { LiveData } from 'types/mainType';
+import { liveState } from 'utils/recoil/main';
 import { gameTimeToString, isBeforeMin } from 'utils/handleTime';
 import { cancelModalState, matchRefreshBtnState } from 'utils/recoil/match';
 import { errorState } from 'utils/recoil/error';
@@ -32,6 +29,7 @@ export default function CurrentMatchInfo() {
   const [openCancelModal, setOpenCancelModal] =
     useRecoilState(cancelModalState);
   const setErrorMessage = useSetRecoilState(errorState);
+  const setLiveData = useSetRecoilState<LiveData>(liveState);
   const presentPath = useRouter().asPath;
 
   useEffect(() => {
@@ -39,27 +37,24 @@ export default function CurrentMatchInfo() {
   }, []);
 
   useEffect(() => {
-    if (isBeforeMin(time, 5)) {
-      getCurrentMatchHandler();
-      setEnemyTeamInfo(makeEnemyTeamInfo(enemyTeam));
+    getCurrentMatchHandler();
+    if (matchRefreshBtn && isBeforeMin(time, 0)) {
+      setLiveData((prev) => ({ ...prev, event: 'game' }));
     }
-  }, [presentPath]); // 페이지를 바꿀 때, 5분 임박인지 확인후 상대팀 알리기
+  }, [presentPath, matchRefreshBtn]);
 
   const getCurrentMatchHandler = async () => {
     try {
       const res = await instance.get(`/pingpong/match/current`);
       setCurrentMatch(res?.data);
-      if (matchRefreshBtn) {
-        setMatchRefreshBtn(false);
+      if (isBeforeMin(res?.data.time, 5)) {
+        setEnemyTeamInfo(makeEnemyTeamInfo(res?.data.enemyTeam));
       }
+      if (matchRefreshBtn) setMatchRefreshBtn(false);
     } catch (e) {
       setErrorMessage('JB01');
     }
   };
-
-  if (matchRefreshBtn) {
-    getCurrentMatchHandler();
-  } // 매치 페이지의 새로고침 버튼 누를 때, 실행
 
   const onCancel = () => {
     setOpenCancelModal(true);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 현재매치정보배너를 매치페이지 새로고침버튼, 스코어입력 모달과 연결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 현재매치정보 컴포넌트의 데이터 요청 함수(getCurrentMatchHandler) 안에서 경기 5분 임박인지 확인하고 경기 상대를 보여주기
  - path가 바뀌거나 매치페이지 새로고침버튼을 눌렀을 때, 경기 시작 시간이 지났다면 라이브 데이터의 event 상태를 game으로 만들어 스코어 입력 모달 띄우기
 
