### PR TITLE
[Fix] 경기 시간 지난 후 현재매치정보 불러오기에서 시간에 null이 들어가는 문제

### DIFF
--- a/components/Layout/CurrentMatchInfo.tsx
+++ b/components/Layout/CurrentMatchInfo.tsx
@@ -23,7 +23,7 @@ export default function CurrentMatchInfo() {
   });
   const { isMatched, enemyTeam, time, slotId } = currentMatch;
   const [enemyTeamInfo, setEnemyTeamInfo] = useState(<></>);
-  const matchingMessage = makeMessage(time, isMatched);
+  const matchingMessage = time && makeMessage(time, isMatched);
   const [matchRefreshBtn, setMatchRefreshBtn] =
     useRecoilState(matchRefreshBtnState);
   const [openCancelModal, setOpenCancelModal] =


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 경기 시간 지난 후 현재매치정보 불러오기에서 시간에 null이 들어가는 문제
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - time이 null일 때, 함수를 콜하지 않음
 
