### PR TITLE
[fix] login page에서 기존 url이 유효한 문제

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,6 +1,12 @@
 import styles from 'styles/Login.module.scss';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 function Login() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/');
+  }, []);
   return (
     <>
       <div className={styles.loginContainer}>


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 로그인 안했을 경우 어떤 path에서도 로그인페이지로 진입하게 되는데 원래 입력한 url 이 살아있는 문제
  
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - login 페이지에서 router.replace 사용
 
