### PR TITLE
[Fix] 매칭이 안된 경기 취소시 페널티 메시지 삭제 #273

### DIFF
--- a/components/Layout/CurrentMatchInfo.tsx
+++ b/components/Layout/CurrentMatchInfo.tsx
@@ -2,25 +2,21 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { CurrentMatch } from 'types/matchTypes';
-import { LiveData } from 'types/mainType';
-import { liveState } from 'utils/recoil/layout';
-import { gameTimeToString, isBeforeMin } from 'utils/handleTime';
-import { cancelModalState, matchRefreshBtnState } from 'utils/recoil/match';
-import { errorState } from 'utils/recoil/error';
 import Modal from 'components/modal/Modal';
 import CancelControll from 'components/modal/cancel/CancelControll';
+import { liveState } from 'utils/recoil/layout';
+import { errorState } from 'utils/recoil/error';
+import {
+  cancelModalState,
+  matchRefreshBtnState,
+  currentMatchInfo,
+} from 'utils/recoil/match';
+import { gameTimeToString, isBeforeMin } from 'utils/handleTime';
 import instance from 'utils/axios';
 import styles from 'styles/Layout/CurrentMatchInfo.module.scss';
 
 export default function CurrentMatchInfo() {
-  const [currentMatch, setCurrentMatch] = useState<CurrentMatch>({
-    slotId: 0,
-    time: '',
-    isMatched: false,
-    myTeam: [],
-    enemyTeam: [],
-  });
+  const [currentMatch, setCurrentMatch] = useRecoilState(currentMatchInfo);
   const { isMatched, enemyTeam, time, slotId } = currentMatch;
   const [enemyTeamInfo, setEnemyTeamInfo] = useState(<></>);
   const matchingMessage = time && makeMessage(time, isMatched);
@@ -29,7 +25,7 @@ export default function CurrentMatchInfo() {
   const [openCancelModal, setOpenCancelModal] =
     useRecoilState(cancelModalState);
   const setErrorMessage = useSetRecoilState(errorState);
-  const setLiveData = useSetRecoilState<LiveData>(liveState);
+  const setLiveData = useSetRecoilState(liveState);
   const presentPath = useRouter().asPath;
 
   useEffect(() => {

--- a/components/match/MatchBoardList.tsx
+++ b/components/match/MatchBoardList.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
+import MatchBoard from './MatchBoard';
 import { MatchData } from 'types/matchTypes';
 import { matchRefreshBtnState } from 'utils/recoil/match';
 import { errorState } from 'utils/recoil/error';
 import { matchModalState } from 'utils/recoil/match';
 import instance from 'utils/axios';
-import MatchBoard from './MatchBoard';
 import styles from 'styles/match/MatchBoardList.module.scss';
 
 interface MatchBoardListProps {
@@ -44,6 +44,10 @@ export default function MatchBoardList({ type }: MatchBoardListProps) {
   if (!matchData) return null;
 
   const { matchBoards, intervalMinute } = matchData;
+  if (matchBoards.length === 0)
+    return (
+      <div className={styles.matchAllClosed}>❌ 열린 슬롯이 없습니다 😵‍💫 ❌</div>
+    );
   const lastGameTime = matchBoards[matchBoards.length - 1][0].time;
   const lastGameHour = new Date(lastGameTime).getHours();
   const nowHour = new Date().getHours();
@@ -61,7 +65,7 @@ export default function MatchBoardList({ type }: MatchBoardListProps) {
     setMatchRefreshBtn(true);
   };
 
-  const getScrollCurrentRef = (slotsHour: Number) => {
+  const getScrollCurrentRef = (slotsHour: number) => {
     if (nowHour === lastGameHour && slotsHour === nowHour) return currentRef;
     if (slotsHour === nowHour + 1) return currentRef;
     return null;

--- a/components/match/MatchItem.tsx
+++ b/components/match/MatchItem.tsx
@@ -5,9 +5,12 @@ import {
   enrollInfoState,
   matchModalState,
 } from 'utils/recoil/match';
-import { fillZero } from 'utils/handleTime';
-import styles from 'styles/match/MatchItem.module.scss';
+import { errorState } from 'utils/recoil/error';
 import { liveState } from 'utils/recoil/layout';
+import { currentMatchInfo } from 'utils/recoil/match';
+import { fillZero } from 'utils/handleTime';
+import instance from 'utils/axios';
+import styles from 'styles/match/MatchItem.module.scss';
 
 interface MatchItemProps {
   slot: Slot;
@@ -23,6 +26,8 @@ export default function MatchItem({
   const setEnrollInfo = useSetRecoilState<EnrollInfo | null>(enrollInfoState);
   const setMatchModal = useSetRecoilState(matchModalState);
   const setOpenCancelModal = useSetRecoilState<boolean>(cancelModalState);
+  const setErrorMessage = useSetRecoilState(errorState);
+  const setCurrentMatch = useSetRecoilState(currentMatchInfo);
   const liveData = useRecoilValue(liveState);
   const { headCount, slotId, status, time } = slot;
   const headMax = type === 'single' ? 2 : 4;
@@ -32,8 +37,14 @@ export default function MatchItem({
   const isAfterSlot: boolean = startTime.getTime() - new Date().getTime() >= 0;
   let buttonStyle;
 
-  const enrollHandler = () => {
+  const enrollHandler = async () => {
     if (status === 'mytable') {
+      try {
+        const res = await instance.get(`/pingpong/match/current`);
+        setCurrentMatch(res?.data);
+      } catch (e) {
+        setErrorMessage('JB03');
+      }
       setOpenCancelModal(true);
     } else if (liveData.event === 'match') {
       setMatchModal('reject');

--- a/components/modal/cancel/CancelModal.tsx
+++ b/components/modal/cancel/CancelModal.tsx
@@ -1,9 +1,10 @@
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import {
   cancelModalState,
   openCurrentMatchInfoState,
 } from 'utils/recoil/match';
 import { errorState } from 'utils/recoil/error';
+import { currentMatchInfo } from 'utils/recoil/match';
 import instance from 'utils/axios';
 import styles from 'styles/modal/CancelModal.module.scss';
 
@@ -15,6 +16,7 @@ export default function CancelModal({ slotId }: SlotProps) {
   const setOpenModal = useSetRecoilState(cancelModalState);
   const setOpenCurrentInfo = useSetRecoilState(openCurrentMatchInfoState);
   const setErrorMessage = useSetRecoilState(errorState);
+  const currentMatch = useRecoilValue(currentMatchInfo);
 
   const onCancel = async () => {
     try {
@@ -49,11 +51,13 @@ export default function CancelModal({ slotId }: SlotProps) {
           <br />
           취소하시겠습니까?
         </div>
-        <div className={styles.subContent}>
-          &#9888; 지금 경기를 취소하시면
-          <br />
-          1분 간 새로운 예약이 불가합니다!
-        </div>
+        {currentMatch.isMatched && (
+          <div className={styles.subContent}>
+            &#9888; 매칭이 완료된 경기를 취소하면
+            <br />
+            1분 간 새로운 예약이 불가합니다!
+          </div>
+        )}
       </div>
       <div className={styles.buttons}>
         <div className={styles.negative}>

--- a/utils/recoil/match.ts
+++ b/utils/recoil/match.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 import { v1 } from 'uuid';
-import { EnrollInfo } from 'types/matchTypes';
+import { CurrentMatch, EnrollInfo } from 'types/matchTypes';
 
 export const enrollInfoState = atom<EnrollInfo | null>({
   key: `enrollInfoState/${v1()}`,
@@ -25,4 +25,9 @@ export const matchRefreshBtnState = atom<boolean>({
 export const matchModalState = atom<'enroll' | 'reject' | 'manual' | null>({
   key: `matchModalState/${v1()}`,
   default: null,
+});
+
+export const currentMatchInfo = atom<CurrentMatch>({
+  key: `currentMatchInfo/${v1()}`,
+  default: { slotId: 0, time: '', isMatched: false, myTeam: [], enemyTeam: [] },
 });


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 매칭이 안된 경기 취소시 페널티 메시지 삭제
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - currentMatchInfo를 리코일 스테이트로 변경했습니다.
  - 매치아이템 클릭시 currentMatchInfo를 새로 받아옵니다.
  - 매치보드 배열이 비어있을 때 표시할 메시지를 추가했습니다.
 
