### PR TITLE
[feat] 모달 바깥 클릭시 모달 닫기

### DIFF
--- a/components/modal/EditProfileModal.tsx
+++ b/components/modal/EditProfileModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { profileInfoState, isEditProfileState } from 'utils/recoil/user';
+import { profileInfoState, editProfileModalState } from 'utils/recoil/user';
 import { errorState } from 'utils/recoil/error';
 import instance from 'utils/axios';
 import styles from 'styles/user/Profile.module.scss';
@@ -13,7 +13,7 @@ interface EditedProfile {
 const CHAR_LIMIT = 30;
 
 export default function EditProfileModal() {
-  const setIsEditProfile = useSetRecoilState(isEditProfileState);
+  const setIsEditProfile = useSetRecoilState(editProfileModalState);
   const [profileInfo, setProfileInfo] = useRecoilState(profileInfoState);
   const setErrorMessage = useSetRecoilState(errorState);
   const [editedProfile, setEditedProfile] = useState<EditedProfile>({

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,12 +1,35 @@
 import styles from 'styles/modal/Modal.module.scss';
+import { useSetRecoilState } from 'recoil';
+import { cancelModalState, matchModalState } from 'utils/recoil/match';
+import { editProfileModalState } from 'utils/recoil/user';
+import { newLoginState } from 'utils/recoil/layout';
+import { logoutModalState } from 'utils/recoil/login';
 
 type ModalProps = {
   children: React.ReactNode;
 };
 
 export default function Modal({ children }: ModalProps) {
+  const setLogoutModal = useSetRecoilState(logoutModalState);
+  const setEditProfileModal = useSetRecoilState(editProfileModalState);
+  const setMatchModal = useSetRecoilState(matchModalState);
+  const setCancelModal = useSetRecoilState(cancelModalState);
+  const setNewLogin = useSetRecoilState(newLoginState);
+  const modalCloseHandler = (e: React.MouseEvent) => {
+    if (e.target instanceof HTMLDivElement && e.target.id === 'modalOutside') {
+      setLogoutModal(false);
+      setEditProfileModal(false);
+      setMatchModal(null);
+      setCancelModal(false);
+      setNewLogin(false);
+    }
+  };
   return (
-    <div className={styles.backdrop}>
+    <div
+      className={styles.backdrop}
+      id='modalOutside'
+      onClick={modalCloseHandler}
+    >
       <div className={styles.modalContainer}>{children}</div>
     </div>
   );

--- a/components/user/Profile.tsx
+++ b/components/user/Profile.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { useEffect } from 'react';
 import { useSetRecoilState, useRecoilState, useRecoilValue } from 'recoil';
-import { isEditProfileState, profileInfoState } from 'utils/recoil/user';
+import { editProfileModalState, profileInfoState } from 'utils/recoil/user';
 import { userState } from 'utils/recoil/layout';
 import { errorState } from 'utils/recoil/error';
 import instance from 'utils/axios';
@@ -13,7 +13,7 @@ interface ProfileProps {
 
 export default function Profile({ intraId }: ProfileProps) {
   const userData = useRecoilValue(userState);
-  const setIsEditProfile = useSetRecoilState(isEditProfileState);
+  const setIsEditProfile = useSetRecoilState(editProfileModalState);
   const setErrorMessage = useSetRecoilState(errorState);
   const [profileInfo, setProfileInfo] = useRecoilState(profileInfoState);
 

--- a/pages/users/detail.tsx
+++ b/pages/users/detail.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
-import { isEditProfileState } from 'utils/recoil/user';
+import { editProfileModalState } from 'utils/recoil/user';
 import Chart from 'components/user/Chart';
 import Profile from 'components/user/Profile';
 import EditProfileModal from 'components/modal/EditProfileModal';
@@ -12,7 +12,9 @@ import { useEffect } from 'react';
 export default function user() {
   const router = useRouter();
   const { intraId } = router.query;
-  const [isEditProfile, setIsEditProfile] = useRecoilState(isEditProfileState);
+  const [isEditProfile, setIsEditProfile] = useRecoilState(
+    editProfileModalState
+  );
 
   useEffect(() => {
     return setIsEditProfile(false);

--- a/utils/recoil/user.ts
+++ b/utils/recoil/user.ts
@@ -2,8 +2,8 @@ import { ProfileInfo } from './../../types/userTypes';
 import { atom } from 'recoil';
 import { v1 } from 'uuid';
 
-export const isEditProfileState = atom<boolean>({
-  key: `isEditProfileState/${v1()}`,
+export const editProfileModalState = atom<boolean>({
+  key: `editProfileModalState/${v1()}`,
   default: false,
 });
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 모달 바깥 클릭시 모달 닫기
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 모달 관련 recoilstate 들을 Modal.tsx 에 가져와서 (InputScore 제외)
  - 모달 바깥 클릭 시 useSetRecoilState 를 통해 false 혹은 null 처리
  - ProfileEdit Recoil 변수명 `isEditProfileState`에서 `editProfileModalState` 로 변경
 
## 추가 로직 설명
```typescript
// Modal.tsx
const modalCloseHandler = (e: React.MouseEvent) => {
    if (e.target instanceof HTMLDivElement && e.target.id === 'modalOutside') {
      setLogoutModal(false);
      setEditProfileModal(false);
      setMatchModal(null);
      setCancelModal(false);
      setNewLogin(false);
    }
  };
```

MouseEvent 에는 e.target에 id라는 속성이 없어서
if 문에 `e.target instanceof HTMLDivElement` 조건을 넣어서
TypeScript 에게 e.target이 id 라는 속성을 가지고 있음을 알려줌

참고 : https://velog.io/@e_juhee/TypeScript-EventType