### PR TITLE
[Fix] 메인페이지에서 쓰는 랭크 컴포넌트 분리#391

### DIFF
--- a/components/game/GameResult.tsx
+++ b/components/game/GameResult.tsx
@@ -2,13 +2,13 @@ import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { Mode } from 'types/mainType';
+import { RecordMode } from 'types/mainType';
 import { userState } from 'utils/recoil/layout';
 import GameResultList from 'components/game/GameResultList';
 
 interface GameResultProps {
   intraId?: string;
-  mode?: Mode;
+  mode?: RecordMode;
   season?: string;
   isMine?: boolean;
 }

--- a/components/rank/RankList.tsx
+++ b/components/rank/RankList.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { Mode } from 'types/mainType';
+import { MatchMode } from 'types/mainType';
 import { RankMode, NormalMode, Rank } from 'types/rankTypes';
 import { myRankPosition, isMyRankScroll } from 'utils/recoil/myRank';
 import { userState } from 'utils/recoil/layout';
@@ -12,7 +12,7 @@ import RankListFrame from './RankListFrame';
 import RankListItem from './RankListItem';
 
 interface RankListProps {
-  mode?: Mode;
+  mode?: MatchMode;
   season?: string;
 }
 

--- a/components/rank/RankList.tsx
+++ b/components/rank/RankList.tsx
@@ -7,6 +7,7 @@ import { myRankPosition, isMyRankScroll } from 'utils/recoil/myRank';
 import { userState } from 'utils/recoil/layout';
 import { errorState } from 'utils/recoil/error';
 import instance from 'utils/axios';
+import RankListMain from './topRank/RankListMain';
 import RankListFrame from './RankListFrame';
 import RankListItem from './RankListItem';
 
@@ -20,13 +21,15 @@ function isRankModeType(arg: RankMode | NormalMode): arg is RankMode {
 }
 
 export default function RankList({ mode, season }: RankListProps) {
-  const [rank, setRank] = useState<Rank | null>(null);
+  const [rank, setRank] = useState<Rank>();
   const [page, setPage] = useState<number>(1);
   const [myRank, setMyRank] = useRecoilState(myRankPosition);
   const [isScroll, setIsScroll] = useRecoilState(isMyRankScroll);
   const seasonMode = useRecoilValue(userState).seasonMode;
   const setErrorMessage = useSetRecoilState(errorState);
   const router = useRouter();
+  const isMain = router.asPath === '/';
+  const isRankMode = mode === 'rank';
   const pageInfo = {
     currentPage: rank?.currentPage,
     totalPage: rank?.totalPage,
@@ -34,10 +37,10 @@ export default function RankList({ mode, season }: RankListProps) {
   };
 
   const makePath = () => {
-    const modeOption = (mode?: string) =>
-      mode === 'normal' ? 'vip' : 'ranks/single';
-    const seasonOption = mode === 'rank' ? `&season=${season}` : '';
-    return router.asPath === '/'
+    const modeOption = (targetMode?: string) =>
+      targetMode !== 'normal' ? 'ranks/single' : 'vip';
+    const seasonOption = isRankMode ? `&season=${season}` : '';
+    return isMain
       ? `/pingpong/${modeOption(seasonMode)}?page=1&count=3`
       : `/pingpong/${modeOption(mode)}?page=${page}${seasonOption}`;
   };
@@ -69,14 +72,16 @@ export default function RankList({ mode, season }: RankListProps) {
     }
   };
 
+  if (isMain) return <RankListMain rank={rank} />;
+
   return (
-    <RankListFrame modeType={mode} pageInfo={pageInfo}>
+    <RankListFrame isRankMode={isRankMode} pageInfo={pageInfo}>
       {rank?.rankList.map((item: NormalMode | RankMode, index) => (
         <RankListItem
           key={item.intraId}
           index={index}
           rankedUser={item}
-          mode={mode}
+          isRankMode={isRankMode}
           ppp={isRankModeType(item) ? item.ppp : null}
           level={!isRankModeType(item) ? item.level : null}
           exp={!isRankModeType(item) ? item.exp : null}

--- a/components/rank/RankListFrame.tsx
+++ b/components/rank/RankListFrame.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import { Mode } from 'types/mainType';
 import PageNation from 'components/Pagination';
 import styles from 'styles/rank/RankList.module.scss';
 
@@ -10,21 +9,19 @@ interface PageInfo {
 }
 interface RankListFrameProps {
   children: React.ReactNode;
-  modeType?: Mode;
   pageInfo: PageInfo;
+  isRankMode: boolean;
 }
 
 export default function RankListFrame({
   children,
-  modeType,
   pageInfo,
+  isRankMode,
 }: RankListFrameProps) {
-  const mainTitle = modeType === 'rank' ? 'Champion' : 'Vips';
-  const divisionList =
-    modeType === 'rank'
-      ? ['순위', 'intraId', '상태메시지', '점수']
-      : ['열정', 'intraId (Lv)', '상태메시지', '경험치'];
   const router = useRouter();
+  const divisionList = isRankMode
+    ? ['순위', 'intraId', '상태메시지', '점수']
+    : ['열정', 'intraId (Lv)', '상태메시지', '경험치'];
 
   const pageChangeHandler = (pages: number) => {
     pageInfo.setPage(pages);
@@ -33,28 +30,19 @@ export default function RankListFrame({
 
   return (
     <>
-      {router.asPath === '/' ? (
-        <div className={styles.mainContainer}>
-          <div className={styles.mainTitle}>{mainTitle}</div>
-          {children}
+      <div className={styles.container}>
+        <div className={styles.division}>
+          {divisionList.map((item: string) => (
+            <div key={item}>{item}</div>
+          ))}
         </div>
-      ) : (
-        <>
-          <div className={styles.container}>
-            <div className={styles.division}>
-              {divisionList.map((item: string) => (
-                <div key={item}>{item}</div>
-              ))}
-            </div>
-            {children}
-          </div>
-          <PageNation
-            curPage={pageInfo.currentPage}
-            totalPages={pageInfo.totalPage}
-            pageChangeHandler={pageChangeHandler}
-          />
-        </>
-      )}
+        {children}
+      </div>
+      <PageNation
+        curPage={pageInfo.currentPage}
+        totalPages={pageInfo.totalPage}
+        pageChangeHandler={pageChangeHandler}
+      />
     </>
   );
 }

--- a/components/rank/RankListFrame.tsx
+++ b/components/rank/RankListFrame.tsx
@@ -31,7 +31,6 @@ export default function RankListFrame({
   return (
     <>
       <div className={styles.container}>
-        {/* <div className={styles.division}> */}
         <div
           className={`${styles.division}
 					${!isRankMode && styles.normal}`}

--- a/components/rank/RankListFrame.tsx
+++ b/components/rank/RankListFrame.tsx
@@ -31,7 +31,11 @@ export default function RankListFrame({
   return (
     <>
       <div className={styles.container}>
-        <div className={styles.division}>
+        {/* <div className={styles.division}> */}
+        <div
+          className={`${styles.division}
+					${!isRankMode && styles.normal}`}
+        >
           {divisionList.map((item: string) => (
             <div key={item}>{item}</div>
           ))}

--- a/components/rank/RankListItem.tsx
+++ b/components/rank/RankListItem.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
 import { NormalMode, RankMode } from 'types/rankTypes';
-import { Mode } from 'types/mainType';
 import { userState } from 'utils/recoil/layout';
 import styles from 'styles/rank/RankList.module.scss';
 
@@ -36,7 +35,7 @@ export default function RankListItem({
       <span>
         {intraId}
         {!isRankMode && level && (
-          <span className={styles.level}>( {level})</span>
+          <span className={styles.level}> ({level})</span>
         )}
       </span>
     </Link>

--- a/components/rank/RankListItem.tsx
+++ b/components/rank/RankListItem.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { NormalMode, RankMode } from 'types/rankTypes';
 import { Mode } from 'types/mainType';
@@ -9,8 +8,8 @@ import styles from 'styles/rank/RankList.module.scss';
 interface RankListItemRrops {
   index: number;
   rankedUser: NormalMode | RankMode;
-  mode?: Mode;
-  ppp: number | string | null;
+  isRankMode: boolean;
+  ppp: number | null;
   level: number | null;
   exp: number | null;
 }
@@ -18,7 +17,7 @@ interface RankListItemRrops {
 export default function RankListItem({
   index,
   rankedUser,
-  mode,
+  isRankMode,
   ppp,
   level,
   exp,
@@ -30,47 +29,31 @@ export default function RankListItem({
       ? statusMessage.slice(0, 10) + '...'
       : statusMessage;
   const rankFiltered = rank < 0 ? '-' : rank;
-  const pppFiltered = rank < 0 ? '-' : ppp;
-  const router = useRouter();
+  const point = !isRankMode && ppp === null ? exp : rank < 0 ? '-' : ppp;
 
   const makeIntraIdLink = () => (
     <Link href={`/users/detail?intraId=${intraId}`}>
       <span>
-        {mode === 'normal' && level ? (
-          <>
-            {intraId} <span className={styles.level}>({level})</span>
-          </>
-        ) : (
-          intraId
+        {intraId}
+        {!isRankMode && level && (
+          <span className={styles.level}>( {level})</span>
         )}
       </span>
     </Link>
   );
 
   return (
-    <>
-      {router.asPath === '/' ? (
-        <div className={styles.mainData}>
-          <div className={styles.rank}>{rankFiltered}</div>
-          <div className={styles.intraId}>{makeIntraIdLink()}</div>
-          <div className={styles.statusMessage}>{messageFiltered}</div>
-        </div>
-      ) : (
-        <div className={styles.rankData}>
-          <div
-            className={`${index % 2 === 0 ? styles.even : styles.odd}
+    <div className={styles.rankData}>
+      <div
+        className={`${index % 2 === 0 ? styles.even : styles.odd}
             ${rankFiltered < 4 ? styles.topRank : styles.rank}
             ${intraId === myIntraId && styles.myself}`}
-          >
-            {rankFiltered}
-            <div className={styles.intraId}>{makeIntraIdLink()}</div>
-            <div className={styles.statusMessage}>{messageFiltered}</div>
-            <div className={styles.ppp}>
-              {mode === 'normal' && ppp === null ? exp : pppFiltered}
-            </div>
-          </div>
-        </div>
-      )}
-    </>
+      >
+        {rankFiltered}
+        <div className={styles.intraId}>{makeIntraIdLink()}</div>
+        <div className={styles.statusMessage}>{messageFiltered}</div>
+        <div className={styles.ppp}>{point}</div>
+      </div>
+    </div>
   );
 }

--- a/components/rank/topRank/RankListItemMain.tsx
+++ b/components/rank/topRank/RankListItemMain.tsx
@@ -1,13 +1,15 @@
 import Link from 'next/link';
 import { RankMode, NormalMode } from 'types/rankTypes';
-import styles from 'styles/rank/RankList.module.scss';
+import styles from 'styles/rank/RankListMain.module.scss';
 
 interface RankListItemMainProps {
   rankedUser: NormalMode | RankMode;
+  isSeasonNormal: boolean;
 }
 
 export default function RankListItemMain({
   rankedUser,
+  isSeasonNormal,
 }: RankListItemMainProps) {
   const { rank, intraId, statusMessage } = rankedUser;
   const messageFiltered =
@@ -17,8 +19,11 @@ export default function RankListItemMain({
   const rankFiltered = rank < 0 ? '-' : rank;
 
   return (
-    <div className={styles.mainData}>
-      <div className={styles.rank}>{rankFiltered}</div>
+    <div
+      className={`${styles.mainData}
+			${isSeasonNormal && styles.normal}`}
+    >
+      <div className={styles.rankNumber}>{rankFiltered}</div>
       <div className={styles.intraId}>
         <Link href={`/users/detail?intraId=${intraId}`}>
           <span>{intraId}</span>

--- a/components/rank/topRank/RankListItemMain.tsx
+++ b/components/rank/topRank/RankListItemMain.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { RankMode, NormalMode } from 'types/rankTypes';
+import styles from 'styles/rank/RankList.module.scss';
+
+interface RankListItemMainProps {
+  rankedUser: NormalMode | RankMode;
+}
+
+export default function RankListItemMain({
+  rankedUser,
+}: RankListItemMainProps) {
+  const { rank, intraId, statusMessage } = rankedUser;
+  const messageFiltered =
+    statusMessage.length > 10
+      ? statusMessage.slice(0, 10) + '...'
+      : statusMessage;
+  const rankFiltered = rank < 0 ? '-' : rank;
+
+  return (
+    <div className={styles.mainData}>
+      <div className={styles.rank}>{rankFiltered}</div>
+      <div className={styles.intraId}>
+        <Link href={`/users/detail?intraId=${intraId}`}>
+          <span>{intraId}</span>
+        </Link>
+      </div>
+      <div className={styles.statusMessage}>{messageFiltered}</div>
+    </div>
+  );
+}

--- a/components/rank/topRank/RankListMain.tsx
+++ b/components/rank/topRank/RankListMain.tsx
@@ -1,8 +1,8 @@
 import { useRecoilValue } from 'recoil';
 import { RankMode, NormalMode, Rank } from 'types/rankTypes';
 import { userState } from 'utils/recoil/layout';
-import styles from 'styles/rank/RankList.module.scss';
 import RankListItemMain from './RankListItemMain';
+import styles from 'styles/rank/RankListMain.module.scss';
 
 interface RankListMainProps {
   rank?: Rank;
@@ -10,12 +10,22 @@ interface RankListMainProps {
 
 export default function RankListMain({ rank }: RankListMainProps) {
   const seasonMode = useRecoilValue(userState).seasonMode;
-  const mainTitle = seasonMode === 'normal' ? 'Vip' : 'Champion';
+  const isSeasonNormal = seasonMode === 'normal';
+  const mainTitle = isSeasonNormal ? 'Vip' : 'Champion';
   return (
     <div className={styles.mainContainer}>
-      <div className={styles.mainTitle}>{mainTitle}</div>
+      <div
+        className={`${styles.mainTitle}
+				${isSeasonNormal ? styles.normal : styles.rank}`}
+      >
+        {mainTitle}
+      </div>
       {rank?.rankList.map((item: NormalMode | RankMode) => (
-        <RankListItemMain key={item.intraId} rankedUser={item} />
+        <RankListItemMain
+          key={item.intraId}
+          rankedUser={item}
+          isSeasonNormal={isSeasonNormal}
+        />
       ))}
     </div>
   );

--- a/components/rank/topRank/RankListMain.tsx
+++ b/components/rank/topRank/RankListMain.tsx
@@ -1,0 +1,22 @@
+import { useRecoilValue } from 'recoil';
+import { RankMode, NormalMode, Rank } from 'types/rankTypes';
+import { userState } from 'utils/recoil/layout';
+import styles from 'styles/rank/RankList.module.scss';
+import RankListItemMain from './RankListItemMain';
+
+interface RankListMainProps {
+  rank?: Rank;
+}
+
+export default function RankListMain({ rank }: RankListMainProps) {
+  const seasonMode = useRecoilValue(userState).seasonMode;
+  const mainTitle = seasonMode === 'normal' ? 'Vip' : 'Champion';
+  return (
+    <div className={styles.mainContainer}>
+      <div className={styles.mainTitle}>{mainTitle}</div>
+      {rank?.rankList.map((item: NormalMode | RankMode) => (
+        <RankListItemMain key={item.intraId} rankedUser={item} />
+      ))}
+    </div>
+  );
+}

--- a/styles/rank/RankList.module.scss
+++ b/styles/rank/RankList.module.scss
@@ -1,7 +1,6 @@
 @import '../common.scss';
 
 /* 나의 랭킹 */
-
 .myRank {
   height: 2rem;
   line-height: middle;
@@ -29,6 +28,7 @@
   font-size: $small-font;
 }
 
+/* Rank List 구분 */
 @mixin rankGrid {
   display: grid;
   grid-template-columns: 12% 22% auto 14%;
@@ -44,12 +44,15 @@
   }
 }
 
-/* Rank List 구분 */
 .division {
   @include rankGrid;
   background: $pp-red;
   color: white;
   font-weight: 700;
+}
+
+.normal {
+  background: $pp-blue;
 }
 
 .level {
@@ -98,64 +101,6 @@
   .ppp {
     justify-self: center;
     font-weight: 600;
-    color: $winner-blue;
-  }
-}
-
-/* Main */
-
-.mainContainer {
-  font-size: 1.05rem;
-}
-
-.mainTitle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: $big-radius;
-  background: $pp-red;
-  height: 2.9rem;
-  font-size: 1.8rem;
-  color: white;
-  font-family: $title-font;
-  text-shadow: $text-shadow;
-  letter-spacing: 0.1rem;
-}
-
-.mainData {
-  display: grid;
-  grid-template-columns: 1.5fr 2.1fr 4fr;
-  align-items: center;
-  background: $pp-pink;
-  margin-top: 0.2rem;
-  height: 2.9rem;
-  border-radius: $big-radius;
-  .rank {
-    text-align: center;
-    font-weight: 700;
-    color: $pp-red;
-  }
-  .intraId {
-    text-align: left;
-    font-weight: 700;
-    color: black;
-    .ppp {
-      font-weight: 500;
-      font-size: 0.9rem;
-      color: $dark-gray;
-    }
-    span {
-      cursor: pointer;
-    }
-  }
-  .statusMessage {
-    font-size: $medium-font;
-    font-weight: 500;
-    text-align: left;
-    color: $dark-blue;
-  }
-  .winRate {
-    text-align: center;
     color: $winner-blue;
   }
 }

--- a/styles/rank/RankListMain.module.scss
+++ b/styles/rank/RankListMain.module.scss
@@ -1,0 +1,60 @@
+@import '../common.scss';
+
+.mainContainer {
+  font-size: 1.05rem;
+}
+
+.mainTitle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: $big-radius;
+  height: 2.9rem;
+  font-size: 1.8rem;
+  color: white;
+  font-family: $title-font;
+  text-shadow: $text-shadow;
+  letter-spacing: 0.1rem;
+  &.rank {
+    background: $pp-red;
+  }
+  &.normal {
+    background: $pp-blue;
+  }
+}
+
+.mainData {
+  display: grid;
+  grid-template-columns: 1.5fr 2.1fr 4fr;
+  align-items: center;
+  background: $pp-pink;
+  margin-top: 0.2rem;
+  height: 2.9rem;
+  border-radius: $big-radius;
+}
+
+.normal {
+  background: $g2-bottom;
+}
+
+.rankNumber {
+  text-align: center;
+  font-weight: 700;
+  color: $pp-red;
+}
+
+.intraId {
+  text-align: left;
+  font-weight: 700;
+  color: black;
+  span {
+    cursor: pointer;
+  }
+}
+
+.statusMessage {
+  font-size: $medium-font;
+  font-weight: 500;
+  text-align: left;
+  color: $dark-blue;
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 메인페이지에서 쓰는 랭크 컴포넌트 분리
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - topRank 폴더 생성: 매 컴포넌트마다 메인페이지를 확인하는 과정이 불필요하다고 생각되어 메인페이지에서 쓰는 컴포넌트 분리해서 넣어놨습니다
 - #390 : 수정된 모드 타입 적용
 - #393 : 랭크 모드 일반전일 때 다른 스타일링 적용 
