### PR TITLE
[Feat] 게임페이지 검색추가 및 프로필페이지와 연결 #410

### DIFF
--- a/components/game/GameResult.tsx
+++ b/components/game/GameResult.tsx
@@ -1,53 +1,40 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { SeasonMode } from 'types/mainType';
-import { userState } from 'utils/recoil/layout';
 import GameResultList from 'components/game/GameResultList';
 
 interface GameResultProps {
-  intraId?: string;
   mode?: SeasonMode;
   season?: string;
-  isMine?: boolean;
 }
 
-export default function GameResult({
-  intraId,
-  mode,
-  season,
-  isMine,
-}: GameResultProps) {
+export default function GameResult({ mode, season }: GameResultProps) {
   const queryClient = new QueryClient();
-  const myIntraId = useRecoilValue(userState).intraId;
   const [path, setPath] = useState('');
   const router = useRouter();
+  const asPath = router.asPath;
+  const intraId = router.query.intraId;
 
   const makePath = () => {
-    if (router.asPath === '/' || router.asPath.includes('token')) {
+    if (asPath === '/' || asPath.includes('token')) {
       setPath(`/pingpong/games?count=3&gameId=`);
       return;
     }
-    const userOption = isMine
-      ? `/users/${myIntraId}`
-      : intraId
-      ? `/users/${intraId}`
-      : '';
-    const seasonOption = mode === 'rank' ? `season=${season}` : '';
-    const modeOption =
-      mode === 'rank' ? 'mode=rank' : mode === 'normal' ? 'mode=normal' : '';
-    const countOption = intraId ? 'count=5' : '';
-    const query = [modeOption, seasonOption, countOption, 'gameId=']
-      .filter((item) => item !== '')
+    const userQuery = intraId ? `/users/${intraId}` : '';
+    const seasonQuery = mode === 'rank' && `season=${season}`;
+    const modeQuery = mode !== 'both' && `mode=${mode}`;
+    const countQuery = router.pathname === '/users/detail' && 'count=5';
+    const query = [modeQuery, seasonQuery, countQuery, 'gameId=']
+      .filter((item) => item)
       .join('&');
-    setPath(`/pingpong${userOption}/games?${query}`);
+    setPath(`/pingpong${userQuery}/games?${query}`);
     return;
   };
 
   useEffect(() => {
     makePath();
-  }, [router.asPath, mode, season, isMine]);
+  }, [asPath, intraId, mode, season]);
 
   return (
     <div>

--- a/components/game/GameResultList.tsx
+++ b/components/game/GameResultList.tsx
@@ -14,9 +14,9 @@ interface GameResultListProps {
 
 export default function GameResultList({ path }: GameResultListProps) {
   const { data, fetchNextPage, status, remove, refetch } = infScroll(path);
-  const [clickedItemId, setClickedItemId] =
-    useRecoilState(clickedGameItemState);
   const [totalPage, setTotalPage] = useState();
+  const [clickedGameItem, setClickedGameItem] =
+    useRecoilState(clickedGameItemState);
   const router = useRouter();
 
   useEffect(() => {
@@ -27,7 +27,7 @@ export default function GameResultList({ path }: GameResultListProps) {
   useEffect(() => {
     const getTotalPage = data?.pages[data.pages.length - 1].totalPage;
     if (data?.pages.length === 1 && getTotalPage !== 0)
-      setClickedItemId(data?.pages[0].games[0].gameId);
+      setClickedGameItem(data?.pages[0].games[0].gameId);
     setTotalPage(getTotalPage);
   }, [data]);
 
@@ -45,14 +45,14 @@ export default function GameResultList({ path }: GameResultListProps) {
                 <GameResultItem
                   key={game.gameId}
                   game={game}
-                  isBig={clickedItemId === game.gameId}
+                  isBig={clickedGameItem === game.gameId}
                 />
               ))}
             </div>
           ))}
         </>
       )}
-      {status === 'success' && router.asPath !== '/' && totalPage !== 1 && (
+      {status === 'success' && router.asPath === '/game' && totalPage !== 1 && (
         <div className={styles.getButton}>
           <input
             type='button'

--- a/components/mode/GameMode.tsx
+++ b/components/mode/GameMode.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { SeasonMode } from 'types/mainType';
 import { seasonListState } from 'utils/recoil/seasons';
-import IsMineCheckBox from './modeItems/IsMineCheckBox';
 import SeasonDropDown from './modeItems/SeasonDropDown';
+import UserGameSearchBar from './modeItems/UserGameSearchBar';
 import ModeRadiobox from './modeItems/ModeRadiobox';
 import styles from 'styles/mode/ModeSelect.module.scss';
 
@@ -14,16 +13,11 @@ interface GameModeProps {
 
 export default function GameMode({ children }: GameModeProps) {
   const { seasonList } = useRecoilValue(seasonListState);
-  const [isMine, setIsMine] = useState(false);
-  const [season, setSeason] = useState<number>(seasonList[0].id);
+  const [season, setSeason] = useState<number>(seasonList[0]?.id);
   const [radioMode, setRadioMode] = useState<SeasonMode>('both');
 
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setRadioMode(e.target.value as SeasonMode);
-  };
-
-  const isMineCheckBoxHandler = () => {
-    setIsMine((isMine) => !isMine);
   };
 
   const seasonDropDownHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -33,7 +27,7 @@ export default function GameMode({ children }: GameModeProps) {
   return (
     <div>
       <div className={styles.wrapper}>
-        <IsMineCheckBox isMine={isMine} onChange={isMineCheckBoxHandler} />
+        <UserGameSearchBar />
         {radioMode === 'rank' && seasonList && (
           <SeasonDropDown
             seasonList={seasonList}
@@ -46,7 +40,6 @@ export default function GameMode({ children }: GameModeProps) {
       {React.cloneElement(children as React.ReactElement, {
         mode: radioMode,
         season,
-        isMine,
       })}
     </div>
   );

--- a/components/mode/ProfileMode.tsx
+++ b/components/mode/ProfileMode.tsx
@@ -11,7 +11,7 @@ interface ProfileModeProps {
 
 export default function ProfileMode({ children }: ProfileModeProps) {
   const { seasonList } = useRecoilValue(seasonListState);
-  const [season, setSeason] = useState<number>(seasonList[0].id);
+  const [season, setSeason] = useState<number>(seasonList[0]?.id);
 
   const seasonDropDownHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSeason(parseInt(e.target.value));

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -1,11 +1,15 @@
+import { useRouter } from 'next/router';
 import GameResult from 'components/game/GameResult';
 import GameMode from 'components/mode/GameMode';
 import styles from 'styles/game/GameResultItem.module.scss';
 
 export default function Game() {
+  const router = useRouter();
   return (
     <div className={styles.pageWrap}>
-      <h1 className={styles.title}>Record</h1>
+      <h1 className={styles.title} onClick={() => router.replace('/game')}>
+        Record
+      </h1>
       <GameMode>
         <GameResult />
       </GameMode>

--- a/pages/users/detail.tsx
+++ b/pages/users/detail.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import BasicProfile from 'components/user/BasicProfile';
 import GameResult from 'components/game/GameResult';
@@ -15,8 +16,17 @@ export default function user() {
           <h1 className={styles.title}>{intraId}</h1>
           <BasicProfile intraId={intraId} />
           <RankProfile intraId={intraId} />
-          <h2 className={styles.subtitle}>recent record</h2>
-          <GameResult intraId={intraId} />
+          <Link
+            href={{
+              pathname: '/game',
+              query: { intraId: intraId },
+            }}
+          >
+            <h2 id={styles.mine} className={styles.subtitle}>
+              recent record ▶️
+            </h2>
+          </Link>
+          <GameResult />
         </>
       )}
     </div>

--- a/styles/game/GameResultItem.module.scss
+++ b/styles/game/GameResultItem.module.scss
@@ -6,6 +6,7 @@
 
 .title {
   @include pageTitle;
+  cursor: pointer;
 }
 
 .smallContainer {

--- a/styles/main/SearchBar.module.scss
+++ b/styles/main/SearchBar.module.scss
@@ -26,19 +26,28 @@
       cursor: pointer;
     }
   }
+  .dropdown {
+    display: block;
+    position: absolute;
+    top: 2.3rem;
+    left: 0;
+    width: 100%;
+    padding: 0 1rem 0.5rem 1rem;
+    border-radius: 0 0 $small-radius $small-radius;
+    background: white;
+    div {
+      padding: 0.5rem 0;
+      cursor: pointer;
+    }
+  }
 }
 
-.dropdown {
-  display: block;
-  position: absolute;
-  top: 2.3rem;
-  left: 0;
-  width: 100%;
-  padding: 0 1rem 0.5rem 1rem;
-  border-radius: 0 0 $small-radius $small-radius;
-  background: white;
-  div {
-    padding: 0.5rem 0;
-    cursor: pointer;
+#game {
+  z-index: 4;
+  height: 1.6rem;
+  margin: 0;
+  .dropdown {
+    top: 1.25rem;
+    padding: 0 0.8rem 0.5rem 0.8rem;
   }
 }

--- a/styles/mode/IsMineCheckBox.module.scss
+++ b/styles/mode/IsMineCheckBox.module.scss
@@ -34,6 +34,7 @@
   }
   label {
     display: flex;
+    cursor: pointer;
     div {
       margin-left: 1rem;
     }

--- a/styles/user/user.module.scss
+++ b/styles/user/user.module.scss
@@ -16,3 +16,7 @@
   text-align: center;
   letter-spacing: 0.1rem;
 }
+
+#mine {
+  cursor: pointer;
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 게임페이지 검색추가 및 프로필페이지와 연결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - detail 페이지:  'recent record' 클릭하면  `Link query` 로 해당 유저 아이디를 담아 `/game` 페이지로 이동하는 코드 추가
  - game 페이지: 페이지명 'record' 클릭시 최신 데이터로 다시 렌더링 되도록 변경
  - game 페이지 - gameResult: `query`에 따라 데이터 요청 path 변경
  - game 페이지 - gameMode: 검색창 추가 <= 이후 컴포넌트 재사용을 위해 리팩토링 예정!!
  - ‼️이후: 리팩토링 및 css 다듬을 예정입니다!!

