### PR TITLE
[Fix] 게임페이지 더보기 오류 및 깜박임 수정#437

### DIFF
--- a/components/game/GameResultList.tsx
+++ b/components/game/GameResultList.tsx
@@ -25,10 +25,12 @@ export default function GameResultList({ path }: GameResultListProps) {
   }, [path]);
 
   useEffect(() => {
-    const isLastGame = data?.pages[data?.pages.length - 1].isLast;
-    if (data?.pages.length === 1 && !isLastGame)
-      setClickedGameItem(data?.pages[0].games[0].gameId);
-    setIsLast(isLastGame);
+    if (status === 'success') {
+      const gameList = data?.pages;
+      if (gameList[0].games.length)
+        setClickedGameItem(gameList[0].games[0].gameId);
+      setIsLast(gameList[gameList.length - 1].isLast);
+    }
   }, [data]);
 
   if (status === 'success' && !data?.pages[0].games.length) {

--- a/components/mode/modeItems/UserGameSearchBar.tsx
+++ b/components/mode/modeItems/UserGameSearchBar.tsx
@@ -11,8 +11,8 @@ let timer: ReturnType<typeof setTimeout>;
 
 export default function UserGameSearchBar() {
   const router = useRouter();
-  const { intraId } = useRouter().query;
-  const [keyword, setKeyword] = useState<string>(String(intraId || ''));
+  const { intraId } = router.query;
+  const [keyword, setKeyword] = useState<string>('');
   const [showDropDown, setShowDropDown] = useState<boolean>(false);
   const [searchResult, setSearchResult] = useState<string[]>([]);
   const setError = useSetRecoilState(errorState);
@@ -27,6 +27,11 @@ export default function UserGameSearchBar() {
       debounce(getSearchResultHandler, 500)();
     }
   }, [keyword]);
+
+  useEffect(() => {
+    if (intraId) setKeyword(String(intraId));
+    else setKeyword('');
+  }, [router]);
 
   useEffect(() => {
     document.addEventListener('mousedown', clickOutsideHandler);

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -5,9 +5,17 @@ import styles from 'styles/game/GameResultItem.module.scss';
 
 export default function Game() {
   const router = useRouter();
+
   return (
     <div className={styles.pageWrap}>
-      <h1 className={styles.title} onClick={() => router.replace('/game')}>
+      <h1
+        className={styles.title}
+        onClick={() =>
+          router.push(`/game`, undefined, {
+            shallow: true,
+          })
+        }
+      >
         Record
       </h1>
       <GameMode>

--- a/utils/infinityScroll.ts
+++ b/utils/infinityScroll.ts
@@ -18,6 +18,7 @@ export default function infScroll(path: string) {
     onError: () => {
       setError('KP01');
     },
+    keepPreviousData: true,
   });
 
   return result;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 게임페이지 더보기 오류 및 깜박임 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - game.tsx: `router.push` `shallow:true`로 새로고침이 아니라 재렌더링 하도록 수정
  - infinityScroll: `keepPreviousData: true`로 이전 데이터를 킵해두어 깜박임 줄임
  - gameResultList
    - 데이터를 받았을 때, 데이터가 있으면 0번째 Id를 BigItem으로 저장해두기, 
    - 마지막 isLast를 isLast로 저장해 더보기 버튼 보이게 만들기
 
