### PR TITLE
[Fix] 매치 등록/취소 시 live 상태 업데이트 #443

### DIFF
--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -17,7 +17,7 @@ export default function CurrentMatch() {
   const setModal = useSetRecoilState(modalState);
   const setError = useSetRecoilState(errorState);
   const matchingMessage = time && makeMessage(time, isMatched);
-  const isBlockCancelBtn = isBeforeMin(time, 5) && enemyTeam.length;
+  const blockCancelBtn = isBeforeMin(time, 5) && enemyTeam.length;
   const presentPath = useRouter().asPath;
 
   useEffect(() => {
@@ -37,7 +37,7 @@ export default function CurrentMatch() {
   const onCancel = () => {
     setModal({
       modalName: 'MATCH-CANCEL',
-      cancelInfo: { slotId, time, enemyTeam },
+      cancelInfo: { slotId, time, enemyTeam, reload: null },
     });
   };
 
@@ -53,13 +53,13 @@ export default function CurrentMatch() {
         </div>
         <div
           className={
-            isBlockCancelBtn ? styles.blockCancelButton : styles.cancelButton
+            blockCancelBtn ? styles.blockCancelButton : styles.cancelButton
           }
         >
           <input
             type='button'
             onClick={onCancel}
-            value={isBlockCancelBtn ? '취소불가' : '취소하기'}
+            value={blockCancelBtn ? '취소불가' : '취소하기'}
           />
         </div>
       </div>

--- a/components/Layout/CurrentMatch.tsx
+++ b/components/Layout/CurrentMatch.tsx
@@ -37,7 +37,7 @@ export default function CurrentMatch() {
   const onCancel = () => {
     setModal({
       modalName: 'MATCH-CANCEL',
-      cancelInfo: { slotId, time, enemyTeam, reload: null },
+      cancel: { slotId, time, enemyTeam, reload: null },
     });
   };
 

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -54,7 +54,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
 
   useEffect(() => {
     if (user.intraId) {
-      getLiveDataHandler();
+      getLiveHandler();
       if (matchRefreshBtn) setMatchRefreshBtn(false);
     }
   }, [presentPath, user, matchRefreshBtn]);
@@ -76,7 +76,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
     }
   };
 
-  const getLiveDataHandler = async () => {
+  const getLiveHandler = async () => {
     try {
       const res = await instance.get(`/pingpong/users/live`);
       setLive({ ...res?.data });

--- a/components/match/MatchBoard.tsx
+++ b/components/match/MatchBoard.tsx
@@ -10,10 +10,10 @@ import styles from 'styles/match/MatchBoard.module.scss';
 
 interface MatchBoardProps {
   type: string;
-  mode?: string;
+  toggleMode?: string;
 }
 
-export default function MatchBoard({ type, mode }: MatchBoardProps) {
+export default function MatchBoard({ type, toggleMode }: MatchBoardProps) {
   const [match, setMatch] = useState<Match | null>(null);
   const [spinRefreshButton, setSpinRefreshButton] = useState<boolean>(false);
   const setMatchRefreshBtn = useSetRecoilState(matchRefreshBtnState);
@@ -22,8 +22,8 @@ export default function MatchBoard({ type, mode }: MatchBoardProps) {
   const currentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    getMatchDataHandler();
-  }, [mode]);
+    getMatchHandler();
+  }, [toggleMode]);
 
   useEffect(() => {
     currentRef.current?.scrollIntoView({
@@ -32,10 +32,10 @@ export default function MatchBoard({ type, mode }: MatchBoardProps) {
     });
   }, [match]);
 
-  const getMatchDataHandler = async () => {
+  const getMatchHandler = async () => {
     try {
       const res = await instance.get(
-        `/pingpong/match/tables/${1}/${mode}/${type}`
+        `/pingpong/match/tables/${1}/${toggleMode}/${type}`
       );
       setMatch(res?.data);
     } catch (e) {
@@ -63,7 +63,7 @@ export default function MatchBoard({ type, mode }: MatchBoardProps) {
     setTimeout(() => {
       setSpinRefreshButton(false);
     }, 1000);
-    getMatchDataHandler();
+    getMatchHandler();
     setMatchRefreshBtn(true);
   };
 
@@ -103,10 +103,10 @@ export default function MatchBoard({ type, mode }: MatchBoardProps) {
             >
               <MatchSlotList
                 type={type}
-                mode={mode}
                 intervalMinute={intervalMinute}
+                toggleMode={toggleMode}
                 matchSlots={matchSlots}
-                getMatchDataHandler={getMatchDataHandler}
+                getMatchHandler={getMatchHandler}
               />
             </div>
           );

--- a/components/match/MatchBoard.tsx
+++ b/components/match/MatchBoard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { Match } from 'types/matchTypes';
+import { MatchMode } from 'types/mainType';
 import instance from 'utils/axios';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
@@ -10,7 +11,7 @@ import styles from 'styles/match/MatchBoard.module.scss';
 
 interface MatchBoardProps {
   type: string;
-  toggleMode?: string;
+  toggleMode?: MatchMode;
 }
 
 export default function MatchBoard({ type, toggleMode }: MatchBoardProps) {

--- a/components/match/MatchSlot.tsx
+++ b/components/match/MatchSlot.tsx
@@ -42,7 +42,7 @@ export default function MatchSlot({
           const { slotId, time, enemyTeam } = res.data;
           setModal({
             modalName: 'MATCH-CANCEL',
-            cancelInfo: {
+            cancel: {
               slotId,
               time,
               enemyTeam,
@@ -58,7 +58,7 @@ export default function MatchSlot({
     } else {
       setModal({
         modalName: 'MATCH-ENROLL',
-        enrollInfo: {
+        enroll: {
           slotId,
           type,
           mode: toggleMode,

--- a/components/match/MatchSlot.tsx
+++ b/components/match/MatchSlot.tsx
@@ -1,4 +1,4 @@
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { Slot } from 'types/matchTypes';
 import { errorState } from 'utils/recoil/error';
 import { liveState } from 'utils/recoil/layout';

--- a/components/match/MatchSlot.tsx
+++ b/components/match/MatchSlot.tsx
@@ -76,7 +76,7 @@ export default function MatchSlot({
       const res = await instance.get(`/pingpong/users/live`);
       setLive({ ...res?.data });
     } catch (e) {
-      setError('JB03');
+      setError('JH09');
     }
   };
 

--- a/components/match/MatchSlot.tsx
+++ b/components/match/MatchSlot.tsx
@@ -1,8 +1,9 @@
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { Slot } from 'types/matchTypes';
 import { errorState } from 'utils/recoil/error';
 import { liveState } from 'utils/recoil/layout';
 import { modalState } from 'utils/recoil/modal';
+import { MatchMode } from 'types/mainType';
+import { Slot } from 'types/matchTypes';
 import { fillZero } from 'utils/handleTime';
 import instance from 'utils/axios';
 import styles from 'styles/match/MatchSlot.module.scss';
@@ -10,7 +11,7 @@ import styles from 'styles/match/MatchSlot.module.scss';
 interface MatchSlotProps {
   type: string;
   slot: Slot;
-  toggleMode?: string;
+  toggleMode?: MatchMode;
   intervalMinute: number;
   getMatchHandler: () => void;
 }

--- a/components/match/MatchSlotList.tsx
+++ b/components/match/MatchSlotList.tsx
@@ -4,18 +4,18 @@ import styles from 'styles/match/MatchSlotList.module.scss';
 
 interface MatchSlotListProps {
   type: string;
-  mode?: string;
   intervalMinute: number;
+  toggleMode?: string;
   matchSlots: Slot[];
-  getMatchDataHandler: () => void;
+  getMatchHandler: () => void;
 }
 
 export default function MatchSlotList({
   type,
-  mode,
   intervalMinute,
+  toggleMode,
   matchSlots,
-  getMatchDataHandler,
+  getMatchHandler,
 }: MatchSlotListProps) {
   const slotHour = new Date(matchSlots[0].time).getHours();
   const slotHourIn12 = ChangeHourFrom24To12(slotHour);
@@ -28,10 +28,10 @@ export default function MatchSlotList({
           <MatchSlot
             key={slot.slotId}
             type={type}
-            matchMode={mode}
+            toggleMode={toggleMode}
             slot={slot}
             intervalMinute={intervalMinute}
-            getMatchDataHandler={getMatchDataHandler}
+            getMatchHandler={getMatchHandler}
           ></MatchSlot>
         ))}
       </div>

--- a/components/match/MatchSlotList.tsx
+++ b/components/match/MatchSlotList.tsx
@@ -1,3 +1,4 @@
+import { MatchMode } from 'types/mainType';
 import { Slot } from 'types/matchTypes';
 import MatchSlot from './MatchSlot';
 import styles from 'styles/match/MatchSlotList.module.scss';
@@ -5,7 +6,7 @@ import styles from 'styles/match/MatchSlotList.module.scss';
 interface MatchSlotListProps {
   type: string;
   intervalMinute: number;
-  toggleMode?: string;
+  toggleMode?: MatchMode;
   matchSlots: Slot[];
   getMatchHandler: () => void;
 }

--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -31,7 +31,7 @@ export default function ModalProvider() {
   };
 
   const findModal = () => {
-    const { modalName, cancelInfo, enrollInfo } = modal;
+    const { modalName, cancel, enroll } = modal;
     switch (modalName) {
       case 'MAIN-WELCOME':
         return <WelcomeModal />;
@@ -40,14 +40,14 @@ export default function ModalProvider() {
       case 'MENU-LOGOUT':
         return <LogoutModal />;
       case 'MATCH-ENROLL':
-        return typeof enrollInfo !== 'undefined' ? (
-          <MatchEnrollModal {...enrollInfo} />
+        return typeof enroll !== 'undefined' ? (
+          <MatchEnrollModal {...enroll} />
         ) : null;
       case 'MATCH-REJECT':
         return <MatchRejectModal />;
       case 'MATCH-CANCEL':
-        return typeof cancelInfo !== 'undefined' ? (
-          <CancelController {...cancelInfo} />
+        return typeof cancel !== 'undefined' ? (
+          <CancelController {...cancel} />
         ) : null;
       case 'MATCH-MANUAL':
         return <MatchManualModal />;

--- a/components/modal/afterGame/exp/ExpChangeModal.tsx
+++ b/components/modal/afterGame/exp/ExpChangeModal.tsx
@@ -20,7 +20,7 @@ export default function ExpChangeModal() {
   const getExpHandler = async () => {
     try {
       const res = await instance.get(
-        `/pingpong/games/${modal.gameId}/result/${modal.enrollInfo?.mode}`
+        `/pingpong/games/${modal.gameId}/result/${modal.enroll?.mode}`
       );
       setUser(res?.data);
     } catch (e) {

--- a/components/modal/match/MatchEnrollModal.tsx
+++ b/components/modal/match/MatchEnrollModal.tsx
@@ -12,7 +12,7 @@ export default function MatchEnrollModal({
   mode,
   startTime,
   endTime,
-  getMatchDataHandler,
+  reload,
 }: Enroll) {
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
@@ -36,7 +36,8 @@ export default function MatchEnrollModal({
       }
     }
     setModal({ modalName: null });
-    getMatchDataHandler();
+    reload?.getMatchHandler();
+    reload?.getLiveHandler();
   };
 
   const onCancel = () => {

--- a/components/modal/matchCancel/CancelController.tsx
+++ b/components/modal/matchCancel/CancelController.tsx
@@ -3,7 +3,12 @@ import { isBeforeMin } from 'utils/handleTime';
 import CancelBeforeFiveMinModal from './CancelBeforeFiveMinModal';
 import CancelModal from './CancelModal';
 
-export default function CancelController({ slotId, time, enemyTeam }: Cancel) {
+export default function CancelController({
+  slotId,
+  time,
+  enemyTeam,
+  reload,
+}: Cancel) {
   const matchStartBefore5Min = isBeforeMin(time, 5);
 
   return (
@@ -11,7 +16,7 @@ export default function CancelController({ slotId, time, enemyTeam }: Cancel) {
       {matchStartBefore5Min && enemyTeam.length ? (
         <CancelBeforeFiveMinModal />
       ) : (
-        <CancelModal slotId={slotId} />
+        <CancelModal slotId={slotId} reload={reload} />
       )}
     </>
   );

--- a/components/modal/matchCancel/CancelModal.tsx
+++ b/components/modal/matchCancel/CancelModal.tsx
@@ -1,16 +1,18 @@
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import instance from 'utils/axios';
+import { Reload } from 'types/modalTypes';
 import { errorState } from 'utils/recoil/error';
 import { modalState } from 'utils/recoil/modal';
 import { currentMatchState } from 'utils/recoil/match';
 import { openCurrentMatchState } from 'utils/recoil/match';
 import styles from 'styles/modal/CancelModal.module.scss';
 
-interface SlotProps {
+interface CancelModalProps {
   slotId: number;
+  reload: Reload | null;
 }
 
-export default function CancelModal({ slotId }: SlotProps) {
+export default function CancelModal({ slotId, reload }: CancelModalProps) {
   const setOpenCurrentMatch = useSetRecoilState(openCurrentMatchState);
   const setError = useSetRecoilState(errorState);
   const setModal = useSetRecoilState(modalState);
@@ -33,7 +35,10 @@ export default function CancelModal({ slotId }: SlotProps) {
     }
     setModal({ modalName: null });
     setOpenCurrentMatch(false);
-    window.location.reload();
+    if (reload) {
+      reload.getMatchHandler();
+      reload.getLiveHandler();
+    } else window.location.reload();
   };
 
   const onReturn = () => {

--- a/components/mode/modeWraps/GameModeWrap.tsx
+++ b/components/mode/modeWraps/GameModeWrap.tsx
@@ -1,17 +1,24 @@
-import React from 'react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
+import { SeasonMode } from 'types/mainType';
 import { seasonListState } from 'utils/recoil/seasons';
+import UserGameSearchBar from '../modeItems/UserGameSearchBar';
 import SeasonDropDown from 'components/mode/modeItems/SeasonDropDown';
+import ModeRadiobox from 'components/mode/modeItems/ModeRadiobox';
 import styles from 'styles/mode/ModeWrap.module.scss';
 
-interface ProfileModeProps {
+interface GameModeWrapProps {
   children: React.ReactNode;
 }
 
-export default function ProfileMode({ children }: ProfileModeProps) {
+export default function GameModeWrap({ children }: GameModeWrapProps) {
   const { seasonList } = useRecoilValue(seasonListState);
   const [season, setSeason] = useState<number>(seasonList[0]?.id);
+  const [radioMode, setRadioMode] = useState<SeasonMode>('both');
+
+  const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRadioMode(e.target.value as SeasonMode);
+  };
 
   const seasonDropDownHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSeason(parseInt(e.target.value));
@@ -19,8 +26,9 @@ export default function ProfileMode({ children }: ProfileModeProps) {
 
   return (
     <div>
-      <div className={styles.profileModeWrap}>
-        {seasonList && (
+      <div className={styles.gameModeWrap}>
+        <UserGameSearchBar />
+        {radioMode === 'rank' && seasonList && (
           <SeasonDropDown
             seasonList={seasonList}
             value={season}
@@ -28,7 +36,9 @@ export default function ProfileMode({ children }: ProfileModeProps) {
           />
         )}
       </div>
+      <ModeRadiobox mode={radioMode} onChange={modeChangeHandler} />
       {React.cloneElement(children as React.ReactElement, {
+        mode: radioMode,
         season,
       })}
     </div>

--- a/components/mode/modeWraps/MatchMode.tsx
+++ b/components/mode/modeWraps/MatchMode.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { seasonListState } from 'utils/recoil/seasons';
+import { MatchMode } from 'types/mainType';
 import ModeToggle from 'components/mode/modeItems/ModeToggle';
 import styles from 'styles/mode/ModeWrap.module.scss';
 
@@ -11,7 +12,7 @@ interface MatchModeProps {
 
 export default function MatchMode({ children }: MatchModeProps) {
   const { seasonMode } = useRecoilValue(seasonListState);
-  const [toggleMode, setToggleMode] = useState<string>('rank');
+  const [toggleMode, setToggleMode] = useState<MatchMode>('rank');
 
   const modeToggleHandler = () => {
     setToggleMode((mode) => (mode === 'rank' ? 'normal' : 'rank'));

--- a/components/mode/modeWraps/MatchMode.tsx
+++ b/components/mode/modeWraps/MatchMode.tsx
@@ -29,7 +29,7 @@ export default function MatchMode({ children }: MatchModeProps) {
         </div>
       )}
       {React.cloneElement(children as React.ReactElement, {
-        mode: toggleMode,
+        toggleMode: toggleMode,
       })}
     </div>
   );

--- a/components/mode/modeWraps/MatchModeWrap.tsx
+++ b/components/mode/modeWraps/MatchModeWrap.tsx
@@ -6,11 +6,11 @@ import { MatchMode } from 'types/mainType';
 import ModeToggle from 'components/mode/modeItems/ModeToggle';
 import styles from 'styles/mode/ModeWrap.module.scss';
 
-interface MatchModeProps {
+interface MatchModeWrapProps {
   children: React.ReactNode;
 }
 
-export default function MatchMode({ children }: MatchModeProps) {
+export default function MatchModeWrap({ children }: MatchModeWrapProps) {
   const { seasonMode } = useRecoilValue(seasonListState);
   const [toggleMode, setToggleMode] = useState<MatchMode>('rank');
 

--- a/components/mode/modeWraps/ProfileModeWrap.tsx
+++ b/components/mode/modeWraps/ProfileModeWrap.tsx
@@ -1,24 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { SeasonMode } from 'types/mainType';
 import { seasonListState } from 'utils/recoil/seasons';
-import UserGameSearchBar from '../modeItems/UserGameSearchBar';
 import SeasonDropDown from 'components/mode/modeItems/SeasonDropDown';
-import ModeRadiobox from 'components/mode/modeItems/ModeRadiobox';
 import styles from 'styles/mode/ModeWrap.module.scss';
 
-interface GameModeProps {
+interface ProfileModeWrapProps {
   children: React.ReactNode;
 }
 
-export default function GameMode({ children }: GameModeProps) {
+export default function ProfileModeWrap({ children }: ProfileModeWrapProps) {
   const { seasonList } = useRecoilValue(seasonListState);
   const [season, setSeason] = useState<number>(seasonList[0]?.id);
-  const [radioMode, setRadioMode] = useState<SeasonMode>('both');
-
-  const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setRadioMode(e.target.value as SeasonMode);
-  };
 
   const seasonDropDownHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSeason(parseInt(e.target.value));
@@ -26,9 +19,8 @@ export default function GameMode({ children }: GameModeProps) {
 
   return (
     <div>
-      <div className={styles.gameModeWrap}>
-        <UserGameSearchBar />
-        {radioMode === 'rank' && seasonList && (
+      <div className={styles.profileModeWrap}>
+        {seasonList && (
           <SeasonDropDown
             seasonList={seasonList}
             value={season}
@@ -36,9 +28,7 @@ export default function GameMode({ children }: GameModeProps) {
           />
         )}
       </div>
-      <ModeRadiobox mode={radioMode} onChange={modeChangeHandler} />
       {React.cloneElement(children as React.ReactElement, {
-        mode: radioMode,
         season,
       })}
     </div>

--- a/components/mode/modeWraps/RankModeWrap.tsx
+++ b/components/mode/modeWraps/RankModeWrap.tsx
@@ -6,12 +6,12 @@ import ModeToggle from 'components/mode/modeItems/ModeToggle';
 import SeasonDropDown from 'components/mode/modeItems/SeasonDropDown';
 import styles from 'styles/mode/ModeWrap.module.scss';
 
-interface RankModeProps {
+interface RankModeWrapProps {
   children: React.ReactNode;
   setMode: React.Dispatch<React.SetStateAction<MatchMode>>;
 }
 
-export default function RankMode({ children, setMode }: RankModeProps) {
+export default function RankModeWrap({ children, setMode }: RankModeWrapProps) {
   const { seasonMode, seasonList } = useRecoilValue(seasonListState);
   const [season, setSeason] = useState<number>(seasonList[0]?.id);
   const [toggleMode, setToggleMode] = useState<MatchMode>(

--- a/components/user/RankProfile.tsx
+++ b/components/user/RankProfile.tsx
@@ -4,7 +4,7 @@ import { ProfileRank } from 'types/userTypes';
 import { errorState } from 'utils/recoil/error';
 import instance from 'utils/axios';
 import Chart from 'components/user/ProfileChart';
-import ProfileMode from 'components/mode/modeWraps/ProfileMode';
+import ProfileModeWrap from 'components/mode/modeWraps/ProfileModeWrap';
 import styles from 'styles/user/Profile.module.scss';
 
 interface RankProfileProps {
@@ -19,9 +19,9 @@ interface RankProps {
 export default function RankProfile({ intraId }: RankProfileProps) {
   return (
     <div className={styles.container}>
-      <ProfileMode>
+      <ProfileModeWrap>
         <Profile intraId={intraId} />
-      </ProfileMode>
+      </ProfileModeWrap>
     </div>
   );
 }

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import GameResult from 'components/game/GameResult';
-import GameMode from 'components/mode/modeWraps/GameMode';
+import GameModeWrap from 'components/mode/modeWraps/GameModeWrap';
 import styles from 'styles/game/GameResultItem.module.scss';
 
 export default function Game() {
@@ -18,9 +18,9 @@ export default function Game() {
       >
         Record
       </h1>
-      <GameMode>
+      <GameModeWrap>
         <GameResult />
-      </GameMode>
+      </GameModeWrap>
     </div>
   );
 }

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -1,14 +1,14 @@
 import MatchBoard from 'components/match/MatchBoard';
-import MatchMode from 'components/mode/modeWraps/MatchMode';
+import MatchModeWrap from 'components/mode/modeWraps/MatchModeWrap';
 import styles from 'styles/match/match.module.scss';
 
 export default function Match() {
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Match</h1>
-      <MatchMode>
+      <MatchModeWrap>
         <MatchBoard type='single' />
-      </MatchMode>
+      </MatchModeWrap>
     </div>
   );
 }

--- a/pages/rank.tsx
+++ b/pages/rank.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { seasonListState } from 'utils/recoil/seasons';
 import { MatchMode } from 'types/mainType';
-import RankMode from 'components/mode/modeWraps/RankMode';
+import RankModeWrap from 'components/mode/modeWraps/RankModeWrap';
 import MyRank from 'components/rank/MyRank';
 import RankList from 'components/rank/RankList';
 import styles from 'styles/rank/RankList.module.scss';
@@ -19,9 +19,9 @@ export default function Rank() {
         {mode === 'rank' ? 'Ranking' : 'VIP'}
       </h1>
       <MyRank />
-      <RankMode setMode={setMode}>
+      <RankModeWrap setMode={setMode}>
         <RankList />
-      </RankMode>
+      </RankModeWrap>
     </div>
   );
 }

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -38,7 +38,7 @@ export interface Enroll {
 
 export interface Modal {
   modalName: ModalName;
-  cancelInfo?: Cancel;
-  enrollInfo?: Enroll;
+  cancel?: Cancel;
+  enroll?: Enroll;
   gameId?: number;
 }

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -16,10 +16,15 @@ type ModalName =
   | `USER-${UserModal}`
   | `FIXED-${FixedModal}`;
 
+export interface Reload {
+  getMatchHandler: () => void;
+  getLiveHandler: () => void;
+}
 export interface Cancel {
   slotId: number;
   time: string;
   enemyTeam: string[];
+  reload: Reload | null;
 }
 
 export interface Enroll {
@@ -28,7 +33,7 @@ export interface Enroll {
   mode?: string;
   startTime: Date;
   endTime: Date;
-  getMatchDataHandler: () => void;
+  reload: Reload | null;
 }
 
 export interface Modal {

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -1,3 +1,5 @@
+import { MatchMode } from './mainType';
+
 type MainModal = 'WELCOME';
 
 type MenuModal = 'REPORT' | 'LOGOUT';
@@ -30,7 +32,7 @@ export interface Cancel {
 export interface Enroll {
   slotId: number;
   type: string;
-  mode?: string;
+  mode?: MatchMode;
   startTime: Date;
   endTime: Date;
   reload: Reload | null;


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 매치 등록/취소 시 live 상태 업데이트
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 매치 enrollInfo(現 enroll), cancelInfo(現 cancel)에 상태 업데이트를 위한 함수 타입을 추가했습니다.
  - 매치 페이지에서 매치 등록/취소 시 페이지 전체 새로고침이 이루어지지 않고 match, live 상태만 비동기적으로 업데이트 됩니다.
  - currentMatch 에서 매치 취소할 경우에는 원래 로직대로 페이지 전체가 새로고침 됩니다.
