### PR TITLE
[Fix] 게임페이지 url로 잘못된 유저 이름 접근시 에러코드 받아 에러페이지로 넘기기, 타이틀 클릭시 초기화  #434

### DIFF
--- a/components/mode/modeWraps/GameModeWrap.tsx
+++ b/components/mode/modeWraps/GameModeWrap.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { SeasonMode } from 'types/mainType';
 import { seasonListState } from 'utils/recoil/seasons';
@@ -9,12 +9,26 @@ import styles from 'styles/mode/ModeWrap.module.scss';
 
 interface GameModeWrapProps {
   children: React.ReactNode;
+  clickedTitle: boolean;
+  setClickedTitle: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function GameModeWrap({ children }: GameModeWrapProps) {
+export default function GameModeWrap({
+  children,
+  clickedTitle,
+  setClickedTitle,
+}: GameModeWrapProps) {
   const { seasonList } = useRecoilValue(seasonListState);
   const [season, setSeason] = useState<number>(seasonList[0]?.id);
   const [radioMode, setRadioMode] = useState<SeasonMode>('both');
+
+  useEffect(() => {
+    if (clickedTitle) {
+      setRadioMode('both');
+      setSeason(seasonList[0]?.id);
+      setClickedTitle(false);
+    }
+  }, [clickedTitle]);
 
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setRadioMode(e.target.value as SeasonMode);

--- a/components/mode/modeWraps/GameModeWrap.tsx
+++ b/components/mode/modeWraps/GameModeWrap.tsx
@@ -9,26 +9,26 @@ import styles from 'styles/mode/ModeWrap.module.scss';
 
 interface GameModeWrapProps {
   children: React.ReactNode;
-  clickedTitle: boolean;
-  setClickedTitle: React.Dispatch<React.SetStateAction<boolean>>;
+  clickTitle: boolean;
+  setClickTitle: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function GameModeWrap({
   children,
-  clickedTitle,
-  setClickedTitle,
+  clickTitle,
+  setClickTitle,
 }: GameModeWrapProps) {
   const { seasonList } = useRecoilValue(seasonListState);
   const [season, setSeason] = useState<number>(seasonList[0]?.id);
   const [radioMode, setRadioMode] = useState<SeasonMode>('both');
 
   useEffect(() => {
-    if (clickedTitle) {
+    if (clickTitle) {
       setRadioMode('both');
       setSeason(seasonList[0]?.id);
-      setClickedTitle(false);
+      setClickTitle(false);
     }
-  }, [clickedTitle]);
+  }, [clickTitle]);
 
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setRadioMode(e.target.value as SeasonMode);

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -6,24 +6,21 @@ import styles from 'styles/game/GameResultItem.module.scss';
 
 export default function Game() {
   const router = useRouter();
-  const [clickedTitle, setClickedTitle] = useState<boolean>(false);
+  const [clickTitle, setClickTitle] = useState<boolean>(false);
 
-  const clickedTitleHandler = () => {
+  const clickTitleHandler = () => {
     router.push(`/game`, undefined, {
       shallow: true,
     });
-    setClickedTitle(true);
+    setClickTitle(true);
   };
 
   return (
     <div className={styles.pageWrap}>
-      <h1 className={styles.title} onClick={clickedTitleHandler}>
+      <h1 className={styles.title} onClick={clickTitleHandler}>
         Record
       </h1>
-      <GameModeWrap
-        clickedTitle={clickedTitle}
-        setClickedTitle={setClickedTitle}
-      >
+      <GameModeWrap clickTitle={clickTitle} setClickTitle={setClickTitle}>
         <GameResult />
       </GameModeWrap>
     </div>

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useRouter } from 'next/router';
 import GameResult from 'components/game/GameResult';
 import GameModeWrap from 'components/mode/modeWraps/GameModeWrap';
@@ -5,20 +6,24 @@ import styles from 'styles/game/GameResultItem.module.scss';
 
 export default function Game() {
   const router = useRouter();
+  const [clickedTitle, setClickedTitle] = useState<boolean>(false);
+
+  const clickedTitleHandler = () => {
+    router.push(`/game`, undefined, {
+      shallow: true,
+    });
+    setClickedTitle(true);
+  };
 
   return (
     <div className={styles.pageWrap}>
-      <h1
-        className={styles.title}
-        onClick={() =>
-          router.push(`/game`, undefined, {
-            shallow: true,
-          })
-        }
-      >
+      <h1 className={styles.title} onClick={clickedTitleHandler}>
         Record
       </h1>
-      <GameModeWrap>
+      <GameModeWrap
+        clickedTitle={clickedTitle}
+        setClickedTitle={setClickedTitle}
+      >
         <GameResult />
       </GameModeWrap>
     </div>

--- a/utils/infinityScroll.ts
+++ b/utils/infinityScroll.ts
@@ -1,4 +1,5 @@
-import { useSetRecoilState } from 'recoil';
+import { useRouter } from 'next/router';
+import { useSetRecoilState, useRecoilState } from 'recoil';
 import { useInfiniteQuery } from 'react-query';
 import { errorState } from 'utils/recoil/error';
 import instance from './axios';
@@ -15,9 +16,11 @@ export default function infScroll(path: string) {
     getNextPageParam: (pages) => {
       return pages.lastGameId;
     },
-    onError: () => {
-      setError('KP01');
+    onError: (e: any) => {
+      if (e.response.data.code === 'UF001') setError('JB07');
+      else setError('KP01');
     },
+    retry: 0,
     keepPreviousData: true,
   });
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 게임페이지 url로 잘못된 유저 이름 접근시 에러코드 받아 에러페이지로 넘기기, 타이틀 클릭시 초기화
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 없는 유저이름 url 접근시 UF001 에러코드 받아 에러페이지로 넘기기(alert으로 처리하려고 했으나 너무 강력해서 에러코드 받아서 에러페이지로 넘기기로 했어융!)
  - 게임페이지 타이틀 클릭시 모드, 시즌 초기화 시키기
 
