### PR TITLE
[Refactor] 랭크페이지 표 구분 및 유저데이터 객체로 한번에 관리하도록 리팩토링 #447

### DIFF
--- a/components/rank/RankList.tsx
+++ b/components/rank/RankList.tsx
@@ -12,7 +12,7 @@ import RankListFrame from './RankListFrame';
 import RankListItem from './RankListItem';
 
 interface RankListProps {
-  mode?: MatchMode;
+  mode: MatchMode;
   season?: string;
 }
 
@@ -80,12 +80,12 @@ export default function RankList({ mode, season }: RankListProps) {
   if (isMain) return <RankListMain rank={rank} />;
 
   return (
-    <RankListFrame mode={mode!} pageInfo={pageInfo}>
+    <RankListFrame mode={mode} pageInfo={pageInfo}>
       {rank?.rankList.map((item: NormalUser | RankUser, index) => (
         <RankListItem
           key={item.intraId}
           index={index}
-          mode={mode!}
+          mode={mode}
           user={makeUser(item)}
         />
       ))}

--- a/components/rank/RankList.tsx
+++ b/components/rank/RankList.tsx
@@ -29,7 +29,6 @@ export default function RankList({ mode, season }: RankListProps) {
   const [page, setPage] = useState<number>(1);
   const router = useRouter();
   const isMain = router.asPath === '/';
-  const isRankSeason = mode === 'rank';
   const pageInfo = {
     currentPage: rank?.currentPage,
     totalPage: rank?.totalPage,
@@ -39,7 +38,7 @@ export default function RankList({ mode, season }: RankListProps) {
   const makePath = () => {
     const modeQuery = (targetMode?: string) =>
       targetMode !== 'normal' ? 'ranks/single' : 'vip';
-    const seasonQuery = isRankSeason ? `&season=${season}` : '';
+    const seasonQuery = mode === 'rank' ? `&season=${season}` : '';
     return isMain
       ? `/pingpong/${modeQuery(seasonMode)}?page=1&count=3`
       : `/pingpong/${modeQuery(mode)}?page=${page}${seasonQuery}`;
@@ -81,18 +80,28 @@ export default function RankList({ mode, season }: RankListProps) {
   if (isMain) return <RankListMain rank={rank} />;
 
   return (
-    <RankListFrame isRankMode={isRankSeason} pageInfo={pageInfo}>
+    <RankListFrame mode={mode!} pageInfo={pageInfo}>
       {rank?.rankList.map((item: NormalUser | RankUser, index) => (
         <RankListItem
           key={item.intraId}
           index={index}
-          user={item}
-          isRankMode={isRankSeason}
-          ppp={isRankModeType(item) ? item.ppp : null}
-          level={!isRankModeType(item) ? item.level : null}
-          exp={!isRankModeType(item) ? item.exp : null}
+          mode={mode!}
+          user={makeUser(item)}
         />
       ))}
     </RankListFrame>
   );
+}
+
+function makeUser(user: NormalUser | RankUser) {
+  const makeStatusMessage = (message: string) =>
+    message.length > 10 ? `${message.slice(0, 10)}...` : message;
+  const makeInit = (init: number) => (user.rank < 0 ? '-' : init);
+  return {
+    intraId: user.intraId,
+    rank: makeInit(user.rank),
+    statusMessage: makeStatusMessage(user.statusMessage),
+    point: !isRankModeType(user) ? user.exp : makeInit(user.ppp),
+    level: !isRankModeType(user) ? user.level : null,
+  };
 }

--- a/components/rank/RankListFrame.tsx
+++ b/components/rank/RankListFrame.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
+import { MatchMode } from 'types/mainType';
 import PageNation from 'components/Pagination';
 import styles from 'styles/rank/RankList.module.scss';
-import { MatchMode } from 'types/mainType';
 
 interface PageInfo {
   currentPage?: number;

--- a/components/rank/RankListFrame.tsx
+++ b/components/rank/RankListFrame.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import PageNation from 'components/Pagination';
 import styles from 'styles/rank/RankList.module.scss';
+import { MatchMode } from 'types/mainType';
 
 interface PageInfo {
   currentPage?: number;
@@ -10,18 +11,19 @@ interface PageInfo {
 interface RankListFrameProps {
   children: React.ReactNode;
   pageInfo: PageInfo;
-  isRankMode: boolean;
+  mode: MatchMode;
 }
 
 export default function RankListFrame({
   children,
   pageInfo,
-  isRankMode,
+  mode,
 }: RankListFrameProps) {
   const router = useRouter();
-  const divisionList = isRankMode
-    ? ['순위', 'intraId', '상태메시지', '점수']
-    : ['열정', 'intraId (Lv)', '상태메시지', '경험치'];
+  const division: { [key: string]: string[] } = {
+    rank: ['순위', 'intraId', '상태메시지', '점수'],
+    normal: ['열정', 'intraId (Lv)', '상태메시지', '경험치'],
+  };
 
   const pageChangeHandler = (pages: number) => {
     pageInfo.setPage(pages);
@@ -33,9 +35,9 @@ export default function RankListFrame({
       <div className={styles.container}>
         <div
           className={`${styles.division}
-					${!isRankMode && styles.normal}`}
+					${mode === 'normal' && styles.normal}`}
         >
-          {divisionList.map((item: string) => (
+          {division[mode].map((item: string) => (
             <div key={item}>{item}</div>
           ))}
         </div>

--- a/components/rank/RankListItem.tsx
+++ b/components/rank/RankListItem.tsx
@@ -1,40 +1,32 @@
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
-import { NormalUser, RankUser } from 'types/rankTypes';
+import { MatchMode } from 'types/mainType';
 import { userState } from 'utils/recoil/layout';
 import styles from 'styles/rank/RankList.module.scss';
 
-interface RankListItemRrops {
-  index: number;
-  user: NormalUser | RankUser;
-  isRankMode: boolean;
-  ppp: number | null;
+interface User {
+  intraId: string;
+  rank: number | string;
+  statusMessage: string;
+  point: number | string;
   level: number | null;
-  exp: number | null;
 }
 
-export default function RankListItem({
-  index,
-  user,
-  isRankMode,
-  ppp,
-  level,
-  exp,
-}: RankListItemRrops) {
-  const { rank, intraId, statusMessage } = user;
+interface RankListItemRrops {
+  index: number;
+  user: User;
+  mode: MatchMode;
+}
+
+export default function RankListItem({ index, user, mode }: RankListItemRrops) {
+  const { rank, intraId, statusMessage, point, level } = user;
   const myIntraId = useRecoilValue(userState).intraId;
-  const messageFiltered =
-    statusMessage.length > 10
-      ? statusMessage.slice(0, 10) + '...'
-      : statusMessage;
-  const rankFiltered = rank < 0 ? '-' : rank;
-  const point = !isRankMode && ppp === null ? exp : rank < 0 ? '-' : ppp;
 
   const makeIntraIdLink = () => (
     <Link href={`/users/detail?intraId=${intraId}`}>
       <span>
         {intraId}
-        {!isRankMode && level && (
+        {mode === 'normal' && level && (
           <span className={styles.level}> ({level})</span>
         )}
       </span>
@@ -45,15 +37,15 @@ export default function RankListItem({
     <div className={styles.rankData}>
       <div
         className={`${index % 2 === 0 ? styles.even : styles.odd}
-            ${rankFiltered < 4 ? styles.topRank : styles.rank}
+            ${rank < 4 ? styles.topRank : styles.rank}
             ${
               intraId === myIntraId &&
-              (isRankMode ? styles.myRanking : styles.myVip)
+              (mode === 'rank' ? styles.myRanking : styles.myVip)
             }`}
       >
-        {rankFiltered}
+        {rank}
         <div className={styles.intraId}>{makeIntraIdLink()}</div>
-        <div className={styles.statusMessage}>{messageFiltered}</div>
+        <div className={styles.statusMessage}>{statusMessage}</div>
         <div className={styles.ppp}>{point}</div>
       </div>
     </div>


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 랭크페이지 표 구분 및 유저데이터 객체로 한번에 관리하도록 리팩토링
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 표 구분 랭크/일반일 때 객체로 만들어서 한번에 관리, 추가 및 재사용 가능!
  - RankList -> RankItem 유저 데이터 보낼 때, 객체로 만들어 보내 확인과정 줄이기!
