### PR TITLE
[Fix] 시즌 기본값 랭크로, 유저 게임 api 수정사항 반영, 모달 새로고침 깜박임 수정

### DIFF
--- a/components/game/GameResult.tsx
+++ b/components/game/GameResult.tsx
@@ -28,7 +28,7 @@ export default function GameResult({ mode, season }: GameResultProps) {
     const query = [modeQuery, seasonQuery, countQuery, 'gameId=']
       .filter((item) => item)
       .join('&');
-    setPath(`/pingpong${userQuery}/games?${query}`);
+    setPath(`/pingpong/games${userQuery}?${query}`);
     return;
   };
 

--- a/components/modal/matchCancel/CancelRejectModal.tsx
+++ b/components/modal/matchCancel/CancelRejectModal.tsx
@@ -1,6 +1,6 @@
-import { useRouter } from 'next/router';
 import { useSetRecoilState } from 'recoil';
 import { modalState } from 'utils/recoil/modal';
+import { reloadMatchState } from 'utils/recoil/match';
 import styles from 'styles/modal/CancelModal.module.scss';
 
 interface CancelRejectModalProps {
@@ -9,7 +9,7 @@ interface CancelRejectModalProps {
 
 export default function CancelRejectModal({ minute }: CancelRejectModalProps) {
   const setModal = useSetRecoilState(modalState);
-  const router = useRouter();
+  const setReloadMatch = useSetRecoilState(reloadMatchState);
   const message = {
     main: ['매칭이 완료되어', <br />, '경기를 취소할 수 없습니다!!'],
     sub: [
@@ -21,7 +21,7 @@ export default function CancelRejectModal({ minute }: CancelRejectModalProps) {
 
   const onReturn = () => {
     setModal({ modalName: null });
-    router.reload();
+    setReloadMatch(true);
   };
 
   return (

--- a/utils/recoil/seasons.ts
+++ b/utils/recoil/seasons.ts
@@ -4,5 +4,5 @@ import { SeasonList } from 'types/seasonTypes';
 
 export const seasonListState = atom<SeasonList>({
   key: `seasonListState/${v1()}`,
-  default: { seasonMode: 'normal', seasonList: [] },
+  default: { seasonMode: 'rank', seasonList: [] },
 });


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 시즌 기본값 랭크로, 유저 게임 api 수정사항 반영, 모달 새로고침 깜박임 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 메인페이지에서 새로고침시 vip가 반짝 보이는 문제 -> 시즌 기본값 랭크로 수정함
  - 유저 게임 api 수정사항 반영: user/intraId/games?~ -> games/user/IntraId?~
  - 모달 새로고침 깜박임 수정: router.reload() -> reloadMatch 리코일을 사용해 재렌더링 시킴
