### PR TITLE
[fix] 컴퓨터 모드에서 celebrate애니메이션이 잘려서 보이는 문제

### DIFF
--- a/components/modal/afterGame/exp/ExpCelebration.tsx
+++ b/components/modal/afterGame/exp/ExpCelebration.tsx
@@ -43,10 +43,8 @@ export default function ExpCelebration() {
   }, []);
 
   return (
-    <div>
-      <div className={styles.wrapper}>
-        <div id='confetti-wrapper'></div>
-      </div>
+    <div className={styles.wrapper}>
+      <div id='confetti-wrapper'></div>
     </div>
   );
 }

--- a/components/modal/afterGame/exp/ExpGuage.tsx
+++ b/components/modal/afterGame/exp/ExpGuage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { modalState } from 'utils/recoil/modal';
 import { sleep } from 'utils/sleep';
-import { Button } from '../score/Buttons';
 import styles from 'styles/modal/ExpGameModal.module.scss';
 import ExpCelebration from './ExpCelebration';
 

--- a/styles/modal/ExpGameModal.module.scss
+++ b/styles/modal/ExpGameModal.module.scss
@@ -110,11 +110,10 @@ $ppp-font: 3.5rem;
 }
 
 .wrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: absolute;
-  width: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
   height: 100vh;
 }
 


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 컴퓨터 모드에서 celebrate애니메이션이 잘려서 보이는 문제
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - css의 position 이 absolute라 위치가 모달에 종속되어서 모달의 시작 부분 부터 나오는 문제 발견
  - position:absolute -> position:fixed 로 변경
  - 사용하지 않는 컴포넌트 제거
 
