### PR TITLE
[Feat] 매치매뉴얼 모달에 일반전 매뉴얼 추가 #487

### DIFF
--- a/components/match/MatchBoard.tsx
+++ b/components/match/MatchBoard.tsx
@@ -40,7 +40,7 @@ export default function MatchBoard({ type, toggleMode }: MatchBoardProps) {
   const getMatchHandler = async () => {
     try {
       const res = await instance.get(
-        `/pingpong/match/tables/${1}/${toggleMode}/${type}`,
+        `/pingpong/match/tables/${1}/${toggleMode}/${type}`
       );
       setMatch(res?.data);
     } catch (e) {

--- a/components/match/MatchBoard.tsx
+++ b/components/match/MatchBoard.tsx
@@ -11,7 +11,7 @@ import styles from 'styles/match/MatchBoard.module.scss';
 
 interface MatchBoardProps {
   type: string;
-  toggleMode?: MatchMode;
+  toggleMode: MatchMode;
 }
 
 export default function MatchBoard({ type, toggleMode }: MatchBoardProps) {
@@ -40,7 +40,7 @@ export default function MatchBoard({ type, toggleMode }: MatchBoardProps) {
   const getMatchHandler = async () => {
     try {
       const res = await instance.get(
-        `/pingpong/match/tables/${1}/${toggleMode}/${type}`
+        `/pingpong/match/tables/${1}/${toggleMode}/${type}`,
       );
       setMatch(res?.data);
     } catch (e) {
@@ -60,7 +60,7 @@ export default function MatchBoard({ type, toggleMode }: MatchBoardProps) {
   const currentHour = new Date().getHours();
 
   const openManual = () => {
-    setModal({ modalName: 'MATCH-MANUAL' });
+    setModal({ modalName: 'MATCH-MANUAL', manual: { toggleMode: toggleMode } });
   };
 
   const reloadMatchHandler = () => {

--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -68,7 +68,7 @@ export default function ModalProvider() {
     modal.modalName && (
       <div
         className={styles.backdrop}
-        id="modalOutside"
+        id='modalOutside'
         onClick={closeModalHandler}
       >
         <div className={styles.modalContainer}>{findModal()}</div>

--- a/components/modal/ModalProvider.tsx
+++ b/components/modal/ModalProvider.tsx
@@ -31,7 +31,7 @@ export default function ModalProvider() {
   };
 
   const findModal = () => {
-    const { modalName, cancel, enroll } = modal;
+    const { modalName, cancel, enroll, manual } = modal;
     switch (modalName) {
       case 'MAIN-WELCOME':
         return <WelcomeModal />;
@@ -50,7 +50,9 @@ export default function ModalProvider() {
           <CancelModal {...cancel} />
         ) : null;
       case 'MATCH-MANUAL':
-        return <MatchManualModal />;
+        return typeof manual !== 'undefined' ? (
+          <MatchManualModal {...manual} />
+        ) : null;
       case 'USER-PROFILE_EDIT':
         return <EditProfileModal />;
       case 'FIXED-AFTER_GAME':
@@ -66,7 +68,7 @@ export default function ModalProvider() {
     modal.modalName && (
       <div
         className={styles.backdrop}
-        id='modalOutside'
+        id="modalOutside"
         onClick={closeModalHandler}
       >
         <div className={styles.modalContainer}>{findModal()}</div>

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -91,7 +91,6 @@ export default function MatchManualModal({ toggleMode }: Manual) {
   const [modalToggleMode, setModalToggleMode] = useState(toggleMode);
 
   const onToggle = () => {
-    console.log('mkdal toggle');
     setModalToggleMode(modalToggleMode === 'rank' ? 'normal' : 'rank');
   };
 
@@ -99,12 +98,14 @@ export default function MatchManualModal({ toggleMode }: Manual) {
     <div className={styles.container}>
       <div className={styles.title}>Please!!</div>
       {seasonMode === 'both' && (
-        <ModeToggle
-          checked={modalToggleMode === 'rank'}
-          onToggle={onToggle}
-          id={'modalToggle'}
-          text={modalToggleMode === 'rank' ? '랭크' : '일반'}
-        />
+        <div className={styles.toggleContainer}>
+          <ModeToggle
+            checked={modalToggleMode === 'rank'}
+            onToggle={onToggle}
+            id={'modalToggle'}
+            text={modalToggleMode === 'rank' ? '랭크' : '일반'}
+          />
+        </div>
       )}
       {modalToggleMode === 'rank' && (
         <ul className={styles.ruleList}>

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { MatchMode } from 'types/mainType';
 import { Manual } from 'types/modalTypes';
 import { modalState } from 'utils/recoil/modal';
 import { seasonListState } from 'utils/recoil/seasons';
 import ModeToggle from 'components/mode/modeItems/ModeToggle';
 import styles from 'styles/modal/MatchManualModal.module.scss';
-import { MatchMode } from 'types/mainType';
 
 export default function MatchManualModal({ toggleMode }: Manual) {
   const setModal = useSetRecoilState(modalState);
@@ -49,7 +49,7 @@ export default function MatchManualModal({ toggleMode }: Manual) {
       </ul>
       <div className={styles.buttons}>
         <div className={styles.positive}>
-          <input onClick={onReturn} type="button" value={'확 인'} />
+          <input onClick={onReturn} type='button' value={'확 인'} />
         </div>
       </div>
     </div>

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -18,12 +18,15 @@ const modalContentsNormal: { title: string; description: string[] }[] = [
     ],
   },
   {
-    title: '🌀 일반 경기',
-    description: ['게임 시작 후 10분이 경과해야 게임 종료 가능'],
+    title: '📖 일반 경기 규칙',
+    description: ['자유 규칙 !'],
   },
   {
     title: '✅ 경기 결과',
-    description: ['일반 게임 진행 시 점수 입력 없음'],
+    description: [
+      '일반 게임 진행 시 점수 입력 없음',
+      '게임 시작 후 10분이 경과해야 게임 종료 가능',
+    ],
   },
   {
     title: '🚨 경기 시 주의사항',
@@ -38,13 +41,13 @@ const modalContentsRank: { title: string; description: string[] }[] = [
       '등록한 경기가 끝나야만 다음 경기 등록 가능',
       '경기 시작 5분 전 상대 팀 공개 및 경기 취소 불가',
       '매칭 알림은 이메일로 전달',
-      '일정 점수 이상 차이 나는 상대와 랭크 경기 불가',
       '경기가 매칭된 상태에서 취소 시, 1분간 경기 등록 불가',
       '상대방이 경기를 취소하면 나의 경기는 매칭 대기 상태로 전환',
+      '일정 점수 이상 차이 나는 상대와 랭크 경기 불가',
     ],
   },
   {
-    title: '📖 경기 규칙',
+    title: '📖 랭크 경기 규칙',
     description: [
       '11점 3판 2선승제',
       '경기는 10분 동안 진행',
@@ -55,7 +58,7 @@ const modalContentsRank: { title: string; description: string[] }[] = [
     ],
   },
   {
-    title: '🏓 서브',
+    title: '🏓 서브 규칙',
     description: [
       '첫 세트만 서브 게임 진행',
       '서브 게임 승자부터 세트별 교대로 서브',

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -2,7 +2,32 @@ import { useSetRecoilState } from 'recoil';
 import { modalState } from 'utils/recoil/modal';
 import styles from 'styles/modal/MatchManualModal.module.scss';
 
-const modalContents: { title: string; description: string[] }[] = [
+const modalContentsNormal: { title: string; description: string[] }[] = [
+  {
+    title: '🔍 매칭',
+    description: [
+      '등록한 경기가 끝나야만 다음 경기 등록 가능',
+      '경기 시작 5분 전 상대 팀 공개 및 경기 취소 불가',
+      '매칭 알림은 이메일로 전달',
+      '경기가 매칭된 상태에서 취소 시, 1분간 경기 등록 불가',
+      '상대방이 경기를 취소하면 나의 경기는 매칭 대기 상태로 전환',
+    ],
+  },
+  {
+    title: '🌀 일반 경기',
+    description: ['게임 시작 후 10분이 경과해야 게임 종료 가능'],
+  },
+  {
+    title: '✅ 경기 결과',
+    description: ['일반 게임 진행 시 점수 입력 없음'],
+  },
+  {
+    title: '🚨 경기 시 주의사항',
+    description: [`노쇼는 건의사항 기능 이용해서 신고`],
+  },
+];
+
+const modalContentsRank: { title: string; description: string[] }[] = [
   {
     title: '🔍 매칭',
     description: [
@@ -15,14 +40,7 @@ const modalContents: { title: string; description: string[] }[] = [
     ],
   },
   {
-    title: '🌀 일반 경기',
-    description: [
-      '일반 게임 진행 시 점수 입력 없음',
-      '게임 시작 후 10분이 경과해야 게임 종료 가능',
-    ],
-  },
-  {
-    title: '📖 랭크 경기',
+    title: '📖 경기 규칙',
     description: [
       '11점 3판 2선승제',
       '경기는 10분 동안 진행',
@@ -46,12 +64,12 @@ const modalContents: { title: string; description: string[] }[] = [
     title: '✅ 경기 결과',
     description: [
       '경기 종료 후 그 자리에서 세트 점수 입력',
-      '다음 경기가 있을 시 현재 스코어가 높은 선수가 승리',
+      '종료시간에 다음 경기가 있을 시 현재 스코어가 높은 선수가 승리',
       '다음 경기가 없을 시 계속 진행',
     ],
   },
   {
-    title: '🚨 경기 시 주의사항',
+    title: '🚨 노쇼',
     description: [
       `매치가 시작 되었으나 상대방이 나오지 않는다면\n3분이 지날 때 마다 세트 점수 1점씩 획득`,
       '6분이 지났을 때도 나오지 않았다면 세트 점수 2:0 승리 처리',
@@ -70,20 +88,22 @@ export default function MatchManualModal() {
     <div className={styles.container}>
       <div className={styles.title}>Please!!</div>
       <ul className={styles.ruleList}>
-        {modalContents.map((item: { title: string; description: string[] }, i) => (
-          <li key={i}>
-            {item.title}
-            <ul className={styles.ruleDetail}>
-              {item.description.map((d, i) => (
-                <li key={i}>{d}</li>
-              ))}
-            </ul>
-          </li>
-        ))}
+        {modalContentsRank.map(
+          (item: { title: string; description: string[] }, i) => (
+            <li key={i}>
+              {item.title}
+              <ul className={styles.ruleDetail}>
+                {item.description.map((d, i) => (
+                  <li key={i}>{d}</li>
+                ))}
+              </ul>
+            </li>
+          ),
+        )}
       </ul>
       <div className={styles.buttons}>
         <div className={styles.positive}>
-          <input onClick={onReturn} type='button' value={'확 인'} />
+          <input onClick={onReturn} type="button" value={'확 인'} />
         </div>
       </div>
     </div>

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -70,8 +70,8 @@ export default function MatchManualModal() {
     <div className={styles.container}>
       <div className={styles.title}>Please!!</div>
       <ul className={styles.ruleList}>
-        {modalContents.map((item: { title: string; description: string[] }) => (
-          <li>
+        {modalContents.map((item: { title: string; description: string[] }, i) => (
+          <li key={i}>
             {item.title}
             <ul className={styles.ruleDetail}>
               {item.description.map((d, i) => (

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -1,6 +1,10 @@
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { modalState } from 'utils/recoil/modal';
 import styles from 'styles/modal/MatchManualModal.module.scss';
+import { Manual } from 'types/modalTypes';
+import { useState } from 'react';
+import ModeToggle from '../../mode/modeItems/ModeToggle';
+import { seasonListState } from '../../../utils/recoil/seasons';
 
 const modalContentsNormal: { title: string; description: string[] }[] = [
   {
@@ -77,30 +81,63 @@ const modalContentsRank: { title: string; description: string[] }[] = [
   },
 ];
 
-export default function MatchManualModal() {
+export default function MatchManualModal({ toggleMode }: Manual) {
   const setModal = useSetRecoilState(modalState);
-
   const onReturn = () => {
     setModal({ modalName: null });
+  };
+
+  const { seasonMode } = useRecoilValue(seasonListState);
+  const [modalToggleMode, setModalToggleMode] = useState(toggleMode);
+
+  const onToggle = () => {
+    console.log('mkdal toggle');
+    setModalToggleMode(modalToggleMode === 'rank' ? 'normal' : 'rank');
   };
 
   return (
     <div className={styles.container}>
       <div className={styles.title}>Please!!</div>
-      <ul className={styles.ruleList}>
-        {modalContentsRank.map(
-          (item: { title: string; description: string[] }, i) => (
-            <li key={i}>
-              {item.title}
-              <ul className={styles.ruleDetail}>
-                {item.description.map((d, i) => (
-                  <li key={i}>{d}</li>
-                ))}
-              </ul>
-            </li>
-          ),
-        )}
-      </ul>
+      {seasonMode === 'both' && (
+        <ModeToggle
+          checked={modalToggleMode === 'rank'}
+          onToggle={onToggle}
+          id={'modalToggle'}
+          text={modalToggleMode === 'rank' ? '랭크' : '일반'}
+        />
+      )}
+      {modalToggleMode === 'rank' && (
+        <ul className={styles.ruleList}>
+          {modalContentsRank.map(
+            (item: { title: string; description: string[] }, i) => (
+              <li key={i}>
+                {item.title}
+                <ul className={styles.ruleDetail}>
+                  {item.description.map((d, i) => (
+                    <li key={i}>{d}</li>
+                  ))}
+                </ul>
+              </li>
+            ),
+          )}
+        </ul>
+      )}
+      {modalToggleMode === 'normal' && (
+        <ul className={styles.ruleList}>
+          {modalContentsNormal.map(
+            (item: { title: string; description: string[] }, i) => (
+              <li key={i}>
+                {item.title}
+                <ul className={styles.ruleDetail}>
+                  {item.description.map((d, i) => (
+                    <li key={i}>{d}</li>
+                  ))}
+                </ul>
+              </li>
+            ),
+          )}
+        </ul>
+      )}
       <div className={styles.buttons}>
         <div className={styles.positive}>
           <input onClick={onReturn} type="button" value={'확 인'} />

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -10,14 +10,14 @@ import styles from 'styles/modal/MatchManualModal.module.scss';
 export default function MatchManualModal({ toggleMode }: Manual) {
   const setModal = useSetRecoilState(modalState);
   const { seasonMode } = useRecoilValue(seasonListState);
-  const [modalToggleMode, setModalToggleMode] = useState(toggleMode);
+  const [manualMode, setManualMode] = useState(toggleMode);
 
   const onReturn = () => {
     setModal({ modalName: null });
   };
 
   const onToggle = () => {
-    setModalToggleMode(modalToggleMode === 'rank' ? 'normal' : 'rank');
+    setManualMode(manualMode === 'rank' ? 'normal' : 'rank');
   };
 
   return (
@@ -26,15 +26,15 @@ export default function MatchManualModal({ toggleMode }: Manual) {
       {seasonMode === 'both' && (
         <div className={styles.toggleContainer}>
           <ModeToggle
-            checked={modalToggleMode === 'rank'}
+            checked={manualMode === 'rank'}
             onToggle={onToggle}
             id={'modalToggle'}
-            text={modalToggleMode === 'rank' ? '랭크' : '일반'}
+            text={manualMode === 'rank' ? '랭크' : '일반'}
           />
         </div>
       )}
       <ul className={styles.ruleList}>
-        {manualSelect(modalToggleMode).map(
+        {manualSelect(manualMode).map(
           (item: { title: string; description: string[] }, i) => (
             <li key={i}>
               {item.title}
@@ -44,7 +44,7 @@ export default function MatchManualModal({ toggleMode }: Manual) {
                 ))}
               </ul>
             </li>
-          ),
+          )
         )}
       </ul>
       <div className={styles.buttons}>

--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -1,10 +1,60 @@
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { modalState } from 'utils/recoil/modal';
-import styles from 'styles/modal/MatchManualModal.module.scss';
-import { Manual } from 'types/modalTypes';
 import { useState } from 'react';
-import ModeToggle from '../../mode/modeItems/ModeToggle';
-import { seasonListState } from '../../../utils/recoil/seasons';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { Manual } from 'types/modalTypes';
+import { modalState } from 'utils/recoil/modal';
+import { seasonListState } from 'utils/recoil/seasons';
+import ModeToggle from 'components/mode/modeItems/ModeToggle';
+import styles from 'styles/modal/MatchManualModal.module.scss';
+import { MatchMode } from 'types/mainType';
+
+export default function MatchManualModal({ toggleMode }: Manual) {
+  const setModal = useSetRecoilState(modalState);
+  const { seasonMode } = useRecoilValue(seasonListState);
+  const [modalToggleMode, setModalToggleMode] = useState(toggleMode);
+
+  const onReturn = () => {
+    setModal({ modalName: null });
+  };
+
+  const onToggle = () => {
+    setModalToggleMode(modalToggleMode === 'rank' ? 'normal' : 'rank');
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.title}>Please!!</div>
+      {seasonMode === 'both' && (
+        <div className={styles.toggleContainer}>
+          <ModeToggle
+            checked={modalToggleMode === 'rank'}
+            onToggle={onToggle}
+            id={'modalToggle'}
+            text={modalToggleMode === 'rank' ? '랭크' : '일반'}
+          />
+        </div>
+      )}
+      <ul className={styles.ruleList}>
+        {manualSelect(modalToggleMode).map(
+          (item: { title: string; description: string[] }, i) => (
+            <li key={i}>
+              {item.title}
+              <ul className={styles.ruleDetail}>
+                {item.description.map((d, i) => (
+                  <li key={i}>{d}</li>
+                ))}
+              </ul>
+            </li>
+          ),
+        )}
+      </ul>
+      <div className={styles.buttons}>
+        <div className={styles.positive}>
+          <input onClick={onReturn} type="button" value={'확 인'} />
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const modalContentsNormal: { title: string; description: string[] }[] = [
   {
@@ -84,69 +134,5 @@ const modalContentsRank: { title: string; description: string[] }[] = [
   },
 ];
 
-export default function MatchManualModal({ toggleMode }: Manual) {
-  const setModal = useSetRecoilState(modalState);
-  const onReturn = () => {
-    setModal({ modalName: null });
-  };
-
-  const { seasonMode } = useRecoilValue(seasonListState);
-  const [modalToggleMode, setModalToggleMode] = useState(toggleMode);
-
-  const onToggle = () => {
-    setModalToggleMode(modalToggleMode === 'rank' ? 'normal' : 'rank');
-  };
-
-  return (
-    <div className={styles.container}>
-      <div className={styles.title}>Please!!</div>
-      {seasonMode === 'both' && (
-        <div className={styles.toggleContainer}>
-          <ModeToggle
-            checked={modalToggleMode === 'rank'}
-            onToggle={onToggle}
-            id={'modalToggle'}
-            text={modalToggleMode === 'rank' ? '랭크' : '일반'}
-          />
-        </div>
-      )}
-      {modalToggleMode === 'rank' && (
-        <ul className={styles.ruleList}>
-          {modalContentsRank.map(
-            (item: { title: string; description: string[] }, i) => (
-              <li key={i}>
-                {item.title}
-                <ul className={styles.ruleDetail}>
-                  {item.description.map((d, i) => (
-                    <li key={i}>{d}</li>
-                  ))}
-                </ul>
-              </li>
-            ),
-          )}
-        </ul>
-      )}
-      {modalToggleMode === 'normal' && (
-        <ul className={styles.ruleList}>
-          {modalContentsNormal.map(
-            (item: { title: string; description: string[] }, i) => (
-              <li key={i}>
-                {item.title}
-                <ul className={styles.ruleDetail}>
-                  {item.description.map((d, i) => (
-                    <li key={i}>{d}</li>
-                  ))}
-                </ul>
-              </li>
-            ),
-          )}
-        </ul>
-      )}
-      <div className={styles.buttons}>
-        <div className={styles.positive}>
-          <input onClick={onReturn} type="button" value={'확 인'} />
-        </div>
-      </div>
-    </div>
-  );
-}
+const manualSelect = (modalToggleMode: MatchMode) =>
+  modalToggleMode === 'rank' ? modalContentsRank : modalContentsNormal;

--- a/components/mode/modeItems/ModeToggle.tsx
+++ b/components/mode/modeItems/ModeToggle.tsx
@@ -4,24 +4,26 @@ interface ModeToggleProps {
   checked: boolean;
   text: string;
   onToggle: () => void;
+  id: string;
 }
 
 export default function ModeToggle({
   checked,
   text,
   onToggle,
+  id,
 }: ModeToggleProps) {
   return (
     <div>
       <input
-        type='checkbox'
-        id='toggle'
+        type="checkbox"
+        id={id}
         className={styles.toggle}
         checked={checked}
         onChange={onToggle}
         hidden
       />
-      <label htmlFor='toggle' className={styles.toggleSwitch}>
+      <label htmlFor={id} className={styles.toggleSwitch}>
         <span className={styles.toggleText}>{text}</span>
         <span className={styles.toggleButton}></span>
       </label>

--- a/components/mode/modeWraps/MatchModeWrap.tsx
+++ b/components/mode/modeWraps/MatchModeWrap.tsx
@@ -29,6 +29,7 @@ export default function MatchModeWrap({
           <ModeToggle
             checked={toggleMode === 'rank'}
             onToggle={modeToggleHandler}
+            id={'matchToggle'}
             text={toggleMode === 'rank' ? '랭크' : '일반'}
           />
         </div>

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -15,7 +15,7 @@ export default function Match() {
     <div className={styles.container}>
       <h1 className={`${styles.title} ${content[toggleMode].style}`}>Match</h1>
       <MatchModeWrap toggleMode={toggleMode} setToggleMode={setToggleMode}>
-        <MatchBoard type='single' />
+        <MatchBoard toggleMode={toggleMode} type="single" />
       </MatchModeWrap>
     </div>
   );

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -15,7 +15,7 @@ export default function Match() {
     <div className={styles.container}>
       <h1 className={`${styles.title} ${content[toggleMode].style}`}>Match</h1>
       <MatchModeWrap toggleMode={toggleMode} setToggleMode={setToggleMode}>
-        <MatchBoard toggleMode={toggleMode} type="single" />
+        <MatchBoard toggleMode={toggleMode} type='single' />
       </MatchModeWrap>
     </div>
   );

--- a/styles/modal/MatchManualModal.module.scss
+++ b/styles/modal/MatchManualModal.module.scss
@@ -12,31 +12,40 @@
   letter-spacing: 0.1rem;
 }
 
-.ruleList {
-  list-style: none;
-  margin: 1.5rem 0.5rem;
-  width: auto;
-  height: 40vh;
-  max-height: 40vh;
-  color: black;
-  overflow-y: scroll;
-  font-weight: 700;
-
-  >li {
-    margin-top: 1rem;
-  }
+.toggleContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: row-reverse;
+  padding-top: 0.5rem;
+  padding-right: 1rem;
+  margin-bottom: 0.1rem;
 }
 
+.ruleList {
+  list-style: none;
+  margin: 0 0.6rem 0.5rem;
+  width: auto;
+  height: 60vh;
+  max-height: 60vh;
+  color: black;
+  overflow-y: scroll;
+  font-size: 1.2rem;
+  font-weight: 700;
 
+  > li {
+    margin-top: 1.2rem;
+    margin-bottom: 1rem;
+  }
+}
 
 .ruleDetail {
   margin-left: 0.8rem;
   font-size: 0.9rem;
   font-weight: 400;
 
-  >li {
+  > li {
     list-style: square;
-    margin-top: 0.5rem;
+    margin: 0.4rem 0;
     white-space: pre-wrap;
   }
 }

--- a/styles/modal/MatchManualModal.module.scss
+++ b/styles/modal/MatchManualModal.module.scss
@@ -23,14 +23,14 @@
 
 .ruleList {
   list-style: none;
-  margin: 0 0.6rem 0.5rem;
   width: auto;
   height: 60vh;
   max-height: 60vh;
+  margin: 0 0.6rem 0.5rem;
   color: black;
-  overflow-y: scroll;
   font-size: 1.2rem;
   font-weight: 700;
+  overflow-y: scroll;
 
   > li {
     margin-top: 1.2rem;

--- a/types/modalTypes.ts
+++ b/types/modalTypes.ts
@@ -37,8 +37,13 @@ export interface Exp {
   mode: MatchMode | null;
 }
 
+export interface Manual {
+  toggleMode: MatchMode;
+}
+
 export interface Modal {
   modalName: ModalName;
+  manual?: Manual;
   cancel?: Cancel;
   enroll?: Enroll;
   exp?: Exp;


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 매뉴얼 모달에 토글 추가
  - 매뉴얼 내용 추가 및 스타일 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 매치에서 일반전 / 랭크전 토글 상태에 따라 맞는 토글의 매뉴얼 모달 오픈
  - 모달 닫으면 돌아가는 매치페이지에서는 모달의 토글과 상관없이 모달 진입시의 토글 상태 유지