### PR TITLE
[Fix] 랭크페이지 토글 작동 안하는 문제 #502

### DIFF
--- a/components/modal/match/MatchManualModal.tsx
+++ b/components/modal/match/MatchManualModal.tsx
@@ -28,7 +28,7 @@ export default function MatchManualModal({ toggleMode }: Manual) {
           <ModeToggle
             checked={manualMode === 'rank'}
             onToggle={onToggle}
-            id={'modalToggle'}
+            id={'manualToggle'}
             text={manualMode === 'rank' ? '랭크' : '일반'}
           />
         </div>

--- a/components/mode/modeWraps/RankModeWrap.tsx
+++ b/components/mode/modeWraps/RankModeWrap.tsx
@@ -41,7 +41,7 @@ export default function RankModeWrap({ children, setMode }: RankModeWrapProps) {
           checked={toggleMode === 'rank'}
           onToggle={modeToggleHandler}
           text={toggleMode === 'rank' ? '랭크' : '일반'}
-          id={'rank'}
+          id={'rankToggle'}
         />
         {showSeasons && seasonList && (
           <SeasonDropDown

--- a/components/mode/modeWraps/RankModeWrap.tsx
+++ b/components/mode/modeWraps/RankModeWrap.tsx
@@ -41,6 +41,7 @@ export default function RankModeWrap({ children, setMode }: RankModeWrapProps) {
           checked={toggleMode === 'rank'}
           onToggle={modeToggleHandler}
           text={toggleMode === 'rank' ? '랭크' : '일반'}
+          id={'rank'}
         />
         {showSeasons && seasonList && (
           <SeasonDropDown


### PR DESCRIPTION

 ## 📌 개요
  - 랭크페이지 토글 작동 안하는 문제 #502

 ## 💻 작업사항
  - 매치매뉴얼 모달에 일반전 매뉴얼 추가 #487 추가하면서 변경된 토글 컴포넌트 rank에서 작동 안하는 문제 수정
 