### PR TITLE
[Fix]프로필 페이지 42레벨일 경우 경험치 Max Exp로 수정 #496

### DIFF
--- a/components/user/BasicProfile.tsx
+++ b/components/user/BasicProfile.tsx
@@ -30,6 +30,7 @@ export default function BasicProfile({ intraId }: ProfileProps) {
     setProfile,
   ] = useRecoilState(profileState);
   const [imgError, setImgError] = useState(false);
+  const MAX_LEVEL = 42;
 
   useEffect(() => {
     getBasicProfileHandler();
@@ -72,7 +73,9 @@ export default function BasicProfile({ intraId }: ProfileProps) {
           <div className={styles.level}>Lv. {level}</div>
           <div className={styles.exp}>
             <div className={styles.expRate}>
-              {currentExp} / {maxExp}
+              {level !== MAX_LEVEL
+                ? `EXP : ${currentExp} / ${maxExp}`
+                : `EXP : ${currentExp} / Max Exp`}
             </div>
             <div className={styles.bar}>
               <span


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 프로필 페이지에서 42레벨의 경우 경험치를 (현재 경험치) / Max Exp 로 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - MAX_LEVEL = 42 추가