### PR TITLE
[Refactor] 게임페이지 리스트 클릭할 때마다 모든 컴포넌트 리렌더링되는 문제#516

### DIFF
--- a/components/game/big/GameResultBigItem.tsx
+++ b/components/game/big/GameResultBigItem.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useSetRecoilState } from 'recoil';
 import { Game } from 'types/gameTypes';
 import { clickedGameItemState } from 'utils/recoil/game';
@@ -9,7 +10,8 @@ interface GameResultBigItemProps {
   game: Game;
 }
 
-export default function GameResultBigItem({ game }: GameResultBigItemProps) {
+function GameResultBigItem({ game }: GameResultBigItemProps) {
+  console.log('big');
   const { mode, team1, team2, status, time, gameId } = game;
   const setClickedItemId = useSetRecoilState(clickedGameItemState);
   return (
@@ -30,3 +32,5 @@ export default function GameResultBigItem({ game }: GameResultBigItemProps) {
     </div>
   );
 }
+
+export default React.memo(GameResultBigItem);

--- a/components/game/big/GameResultBigItem.tsx
+++ b/components/game/big/GameResultBigItem.tsx
@@ -11,7 +11,6 @@ interface GameResultBigItemProps {
 }
 
 function GameResultBigItem({ game }: GameResultBigItemProps) {
-  console.log('big');
   const { mode, team1, team2, status, time, gameId } = game;
   const setClickedItemId = useSetRecoilState(clickedGameItemState);
   return (

--- a/components/game/small/GameResultSmallItem.tsx
+++ b/components/game/small/GameResultSmallItem.tsx
@@ -11,7 +11,6 @@ interface GameResultSmallItemProps {
 }
 
 function GameResultSmallItem({ game }: GameResultSmallItemProps) {
-  console.log('small');
   const { mode, team1, team2, gameId } = game;
   const setClickedItemId = useSetRecoilState(clickedGameItemState);
   return (

--- a/components/game/small/GameResultSmallItem.tsx
+++ b/components/game/small/GameResultSmallItem.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useSetRecoilState } from 'recoil';
 import { Game } from 'types/gameTypes';
 import { clickedGameItemState } from 'utils/recoil/game';
@@ -9,9 +10,8 @@ interface GameResultSmallItemProps {
   game: Game;
 }
 
-export default function GameResultSmallItem({
-  game,
-}: GameResultSmallItemProps) {
+function GameResultSmallItem({ game }: GameResultSmallItemProps) {
+  console.log('small');
   const { mode, team1, team2, gameId } = game;
   const setClickedItemId = useSetRecoilState(clickedGameItemState);
   return (
@@ -30,3 +30,5 @@ export default function GameResultSmallItem({
     </div>
   );
 }
+
+export default React.memo(GameResultSmallItem);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 게임페이지 리스트 클릭할 때마다 모든 컴포넌트 리렌더링되는 문제
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - `React.memo`를 사용해 리스트를 클릭해도 리렌더링이 되지 않게 만들었습니다.
  - `React.memo`는 프롭스가 바뀌지 않으면 다시 렌더링되지 않습니다!!
  - 참고: https://reactjs.org/docs/react-api.html#reactmemo
