### PR TITLE
[Fix] 게임페이지 기록 없을 때 터지는 버그 및 검색시 초기화 안되는 문제 해결 #535

### DIFF
--- a/components/game/GameResultList.tsx
+++ b/components/game/GameResultList.tsx
@@ -28,7 +28,7 @@ export default function GameResultList({ path }: GameResultListProps) {
   useEffect(() => {
     if (status === 'success') {
       const gameList = data?.pages;
-      if (gameList.length === 1)
+      if (gameList.length === 1 && gameList[0].games.length)
         setClickedGameItem(gameList[0].games[0].gameId);
       setIsLast(gameList[gameList.length - 1].isLast);
     }

--- a/components/mode/modeWraps/GameModeWrap.tsx
+++ b/components/mode/modeWraps/GameModeWrap.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { SeasonMode } from 'types/mainType';
@@ -25,14 +26,13 @@ export default function GameModeWrap({
   const latestSeasonId = useRecoilValue(latestSeasonIdState);
   const { seasonList } = useRecoilValue(seasonListState);
   const [season, setSeason] = useState<number>(latestSeasonId);
+  const intraId = useRouter().query.intraId;
 
   useEffect(() => {
-    if (clickTitle) {
-      setRadioMode('both');
-      setSeason(latestSeasonId);
-      setClickTitle(false);
-    }
-  }, [clickTitle]);
+    setRadioMode('both');
+    setSeason(latestSeasonId);
+    if (clickTitle) setClickTitle(false);
+  }, [clickTitle, intraId]);
 
   const modeChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setRadioMode(e.target.value as SeasonMode);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 게임페이지 기록 없을 때 터지는 버그 및 검색시 초기화 안되는 문제 해결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - GameResultList: 빅 아이템 초기 셋팅시 기록 있는지 확인하는 조건 추가
  - gameModeWrap: 쿼리의 인트라 아이디 바뀔 때, 초기화되도록 수정
 
