### PR TITLE
[Fix] 경험치 모달 다음 알림 확인 시 에러페이지로 넘어가는 현상 처리 #508

### DIFF
--- a/components/modal/statChange/StatChangeModal.tsx
+++ b/components/modal/statChange/StatChangeModal.tsx
@@ -4,10 +4,10 @@ import { Exp } from 'types/modalTypes';
 import instance from 'utils/axios';
 import { modalState } from 'utils/recoil/modal';
 import { errorState } from 'utils/recoil/error';
+import { reloadMatchState } from 'utils/recoil/match';
 import ExpStat from './ExpStat';
 import PppStat from 'components/modal/statChange/PppStat';
 import styles from 'styles/modal/StatChangeModal.module.scss';
-import { reloadMatchState } from 'utils/recoil/match';
 
 export default function StatChangeModal({ gameId, mode }: Exp) {
   const setModal = useSetRecoilState(modalState);
@@ -30,17 +30,19 @@ export default function StatChangeModal({ gameId, mode }: Exp) {
     }
   };
 
+  const closeModal = () => {
+    setReloadMatch(true);
+    setModal({ modalName: null });
+  };
+
   if (!stat) return null;
 
   return (
     <div>
       <div
         className={`${styles.fixedContainer} ${styles.front}`}
-        onClick={() => {
-          setReloadMatch(true);
-          setModal({ modalName: null });
-        }}
-      ></div>
+        onClick={closeModal}
+      />
       <div className={styles.container}>
         <div className={styles.emoji}>🏓</div>
         {mode === 'rank' && <PppStat stat={stat} />}

--- a/components/modal/statChange/StatChangeModal.tsx
+++ b/components/modal/statChange/StatChangeModal.tsx
@@ -7,10 +7,12 @@ import { errorState } from 'utils/recoil/error';
 import ExpStat from './ExpStat';
 import PppStat from 'components/modal/statChange/PppStat';
 import styles from 'styles/modal/StatChangeModal.module.scss';
+import { reloadMatchState } from 'utils/recoil/match';
 
 export default function StatChangeModal({ gameId, mode }: Exp) {
   const setModal = useSetRecoilState(modalState);
   const setError = useSetRecoilState(errorState);
+  const setReloadMatch = useSetRecoilState(reloadMatchState);
   const [stat, setStat] = useState();
 
   useEffect(() => {
@@ -34,7 +36,10 @@ export default function StatChangeModal({ gameId, mode }: Exp) {
     <div>
       <div
         className={`${styles.fixedContainer} ${styles.front}`}
-        onClick={() => setModal({ modalName: null })}
+        onClick={() => {
+          setReloadMatch(true);
+          setModal({ modalName: null });
+        }}
       ></div>
       <div className={styles.container}>
         <div className={styles.emoji}>🏓</div>


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 경험치 모달 다음 알림 확인 시 에러페이지로 넘어가는 현상 처리
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - statChangeModal return에 setReloadMatch 추가
 
