### PR TITLE
[Fix] 랭크 리스트에서 내 순위 바로가기 스크롤이 먼저 된 다음 리스트 바뀌는 문제

### DIFF
--- a/components/rank/RankList.tsx
+++ b/components/rank/RankList.tsx
@@ -42,8 +42,20 @@ export default function RankList({
   };
 
   useEffect(() => {
-    getRankDataHandler();
-  }, [page]);
+    async function waitRankList() {
+      await getRankDataHandler();
+    }
+
+    waitRankList().then(() => {
+      if (isScroll) {
+        window.scrollTo({
+          top: ((myRank[toggleMode] - 1) % 20) * 45,
+          behavior: 'smooth',
+        });
+        setIsScroll(false);
+      }
+    });
+  }, [page, isScroll]);
 
   useEffect(() => {
     page !== 1
@@ -56,16 +68,6 @@ export default function RankList({
       setPage(Math.ceil(myRank[toggleMode] / 20));
     }
   }, [isScroll]);
-
-  useEffect(() => {
-    if (isScroll) {
-      window.scrollTo({
-        top: ((myRank[toggleMode] - 1) % 20) * 45,
-        behavior: 'smooth',
-      });
-      setIsScroll(false);
-    }
-  }, [rank, isScroll]);
 
   const getRankDataHandler = async () => {
     try {


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 랭크 리스트에서 내 순위 바로가기 누를 때 스크롤이 먼저 된 다음 리스트 바뀌는 문제 해결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  -  내 순위 바로가기를 눌렀을 때, async await 으로 변경된 페이지의 리스트 로드 기다린 다음 .then에서 스크롤 실행하도록 수정
